### PR TITLE
add models for unifiedTopic annotation

### DIFF
--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/config/HibernateConf.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/config/HibernateConf.java
@@ -13,6 +13,10 @@ import org.texttechnologylab.models.imp.ImportLog;
 import org.texttechnologylab.models.imp.UCEImport;
 import org.texttechnologylab.models.negation.*;
 import org.texttechnologylab.models.test.test;
+import org.texttechnologylab.models.topic.TopicValueBase;
+import org.texttechnologylab.models.topic.TopicValueBaseWithScore;
+import org.texttechnologylab.models.topic.TopicWord;
+import org.texttechnologylab.models.topic.UnifiedTopic;
 
 import java.util.HashMap;
 
@@ -60,6 +64,11 @@ public class HibernateConf {
         metadataSources.addAnnotatedClass(Focus.class);
         metadataSources.addAnnotatedClass(Scope.class);
         metadataSources.addAnnotatedClass(XScope.class);
+        //topics
+        metadataSources.addAnnotatedClass(UnifiedTopic.class);
+        metadataSources.addAnnotatedClass(TopicWord.class);
+        metadataSources.addAnnotatedClass(TopicValueBase.class);
+        metadataSources.addAnnotatedClass(TopicValueBaseWithScore.class);
 
         var metadata = metadataSources.buildMetadata();
 

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/config/corpusConfig/CorpusAnnotationConfig.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/config/corpusConfig/CorpusAnnotationConfig.java
@@ -23,6 +23,8 @@ public class CorpusAnnotationConfig {
     private boolean scope;
     private boolean xscope;
 
+    private boolean unifiedTopic;
+
     public boolean isUceMetadata() {
         return uceMetadata;
     }
@@ -175,4 +177,10 @@ public class CorpusAnnotationConfig {
     public void setXscope(boolean xscope) {
         this.xscope = xscope;
     }
+
+    // UnifiedTopic
+    public boolean isUnifiedTopic() {
+        return unifiedTopic;
+    }
+
 }

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/corpus/Document.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/corpus/Document.java
@@ -10,6 +10,7 @@ import org.texttechnologylab.models.UIMAAnnotation;
 import org.texttechnologylab.models.WikiModel;
 import org.texttechnologylab.models.biofid.BiofidTaxon;
 import org.texttechnologylab.models.negation.*;
+import org.texttechnologylab.models.topic.UnifiedTopic;
 
 import javax.persistence.*;
 import java.util.*;
@@ -114,7 +115,10 @@ public class Document extends ModelBase implements WikiModel {
     @Fetch(value = FetchMode.SUBSELECT)
     private List<XScope> xscopes;
 
-
+    // Unified topics:
+    @OneToMany(mappedBy = "document", cascade = CascadeType.ALL, fetch=FetchType.EAGER)
+    @Fetch(value = FetchMode.SUBSELECT)
+    private List<UnifiedTopic> unifiedTopics;
 
     public Document() {
         metadataTitleInfo = new MetadataTitleInfo();
@@ -303,6 +307,8 @@ public class Document extends ModelBase implements WikiModel {
         annotations.addAll(scopes.stream().filter(a -> a.getBegin() >= pagesBegin && a.getEnd() <= pagesEnd).toList());
         annotations.addAll(xscopes.stream().filter(a -> a.getBegin() >= pagesBegin && a.getEnd() <= pagesEnd).toList());
         annotations.addAll(events.stream().filter(a -> a.getBegin() >= pagesBegin && a.getEnd() <= pagesEnd).toList());
+        // unifiedTopics
+        annotations.addAll(unifiedTopics.stream().filter(a -> a.getBegin() >= pagesBegin && a.getEnd() <= pagesEnd).toList());
 
         annotations.sort(Comparator.comparingInt(UIMAAnnotation::getBegin));
         return annotations;
@@ -393,5 +399,13 @@ public class Document extends ModelBase implements WikiModel {
 
     public void setXscopes(List<XScope> xscopes) {
         this.xscopes = xscopes;
+    }
+
+    public List<UnifiedTopic> getUnifiedTopics() {
+        return unifiedTopics;
+    }
+
+    public void setUnifiedTopics(List<UnifiedTopic> unifiedTopics) {
+        this.unifiedTopics = unifiedTopics;
     }
 }

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicValueBase.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicValueBase.java
@@ -9,6 +9,11 @@ import java.util.List;
 @Entity
 @Table(name = "topicvaluebase")
 public class TopicValueBase extends UIMAAnnotation {
+    /***
+     * TopicValueBase class can be used to represent a topic with a label in a document. It also allows to represent a
+     * topic with a list of word. Therefore, TopicValueBase class has one-to-many relationship with TopicWord class.
+     *
+     */
 
     @ManyToOne
     @JoinColumn(name = "unified_topic_id")

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicValueBase.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicValueBase.java
@@ -1,0 +1,74 @@
+package org.texttechnologylab.models.topic;
+
+import org.texttechnologylab.models.UIMAAnnotation;
+import org.texttechnologylab.models.corpus.Document;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "topic_value_base")
+public class TopicValueBase extends UIMAAnnotation {
+
+    @ManyToOne
+    @JoinColumn(name = "unified_topic_id")
+    private UnifiedTopic unifiedTopic;
+
+    @Column(name = "value", nullable = false)
+    private String value;
+
+    @OneToMany(mappedBy = "topic", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<TopicWord> words;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @JoinColumn(name = "document_id", nullable = false)
+    private Document document;
+
+
+
+
+    public TopicValueBase() {
+        super(-1, -1);
+    }
+
+    public TopicValueBase(int begin, int end) {
+        super(begin, end);
+    }
+
+    public TopicValueBase(int begin, int end, String coveredText) {
+        super(begin, end);
+        setCoveredText(coveredText);
+    }
+    public UnifiedTopic getUnifiedTopic() {
+        return unifiedTopic;
+    }
+
+    public void setUnifiedTopic(UnifiedTopic unifiedTopic) {
+        this.unifiedTopic = unifiedTopic;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public List<TopicWord> getWords() {
+        return words;
+    }
+
+    public void setWords(List<TopicWord> words) {
+        this.words = words;
+    }
+
+    public Document getDocument() {
+        return document;
+    }
+
+    public void setDocument(Document document) {
+        this.document = document;
+    }
+
+}

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicValueBase.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicValueBase.java
@@ -7,7 +7,7 @@ import javax.persistence.*;
 import java.util.List;
 
 @Entity
-@Table(name = "topic_value_base")
+@Table(name = "topicvaluebase")
 public class TopicValueBase extends UIMAAnnotation {
 
     @ManyToOne

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicValueBaseWithScore.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicValueBaseWithScore.java
@@ -7,6 +7,10 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "topicvaluebasewithscore")
 public class TopicValueBaseWithScore extends TopicValueBase {
+    /***
+     * TopicValueBaseWithScore class extends TopicValueBase class to represent a topic in a document with a score.
+     * Therefore, if a topic have a label and a score, it can be represented by TopicValueBaseWithScore class.
+     */
 
     @Column(name = "score", nullable = false)
     private double score;

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicValueBaseWithScore.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicValueBaseWithScore.java
@@ -5,7 +5,7 @@ import javax.persistence.Entity;
 import javax.persistence.Table;
 
 @Entity
-@Table(name = "topic_value_base_with_score")
+@Table(name = "topicvaluebasewithscore")
 public class TopicValueBaseWithScore extends TopicValueBase {
 
     @Column(name = "score", nullable = false)

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicValueBaseWithScore.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicValueBaseWithScore.java
@@ -1,0 +1,35 @@
+package org.texttechnologylab.models.topic;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = "topic_value_base_with_score")
+public class TopicValueBaseWithScore extends TopicValueBase {
+
+    @Column(name = "score", nullable = false)
+    private double score;
+
+
+    public TopicValueBaseWithScore() {
+        super();
+    }
+
+    public TopicValueBaseWithScore(int begin, int end) {
+        super(begin, end);
+    }
+
+    public TopicValueBaseWithScore(int begin, int end, String coveredText) {
+        super(begin, end, coveredText);
+    }
+
+    public double getScore() {
+        return score;
+    }
+
+    public void setScore(double score) {
+        this.score = score;
+    }
+
+}

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicWord.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicWord.java
@@ -5,7 +5,7 @@ import org.texttechnologylab.models.UIMAAnnotation;
 import javax.persistence.*;
 
 @Entity
-@Table(name = "topic_word")
+@Table(name = "topicword")
 public class TopicWord extends UIMAAnnotation {
 
 

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicWord.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicWord.java
@@ -7,8 +7,10 @@ import javax.persistence.*;
 @Entity
 @Table(name = "topicword")
 public class TopicWord extends UIMAAnnotation {
-
-
+    /***
+     * TopicWord class can be used to represent a word in a topic with a probability value. Since each word belongs to
+     * a topic, TopicWord class has a many-to-one relationship with TopicValueBase class.
+     */
 
     @ManyToOne
     @JoinColumn(name = "topic_id")

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicWord.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicWord.java
@@ -1,0 +1,61 @@
+package org.texttechnologylab.models.topic;
+
+import org.texttechnologylab.models.UIMAAnnotation;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "topic_word")
+public class TopicWord extends UIMAAnnotation {
+
+
+
+    @ManyToOne
+    @JoinColumn(name = "topic_id")
+    private TopicValueBase topic;
+
+    @Column(name = "word", nullable = false)
+    private String word;
+
+    @Column(name = "probability")
+    private double probability;
+
+
+    public TopicWord() {
+        super(-1, -1);
+    }
+
+    public TopicWord(int begin, int end) {
+        super(begin, end);
+    }
+
+    public TopicWord(int begin, int end, String coveredText) {
+        super(begin, end);
+        setCoveredText(coveredText);
+    }
+    public TopicValueBase getTopic() {
+        return topic;
+    }
+
+    public void setTopic(TopicValueBase topic) {
+        this.topic = topic;
+    }
+
+    public String getWord() {
+        return word;
+    }
+
+    public void setWord(String word) {
+        this.word = word;
+    }
+
+    public double getProbability() {
+        return probability;
+    }
+
+    public void setProbability(double probability) {
+        this.probability = probability;
+    }
+
+
+}

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/UnifiedTopic.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/UnifiedTopic.java
@@ -11,6 +11,11 @@ import java.util.List;
 @Entity
 @Table(name = "unifiedtopic")
 public class UnifiedTopic extends UIMAAnnotation {
+    /***
+     * UnifiedTopic class can be used to represent the topics in a document. A topic can be represented by a list of
+     * words or category label. Each document can have multiple topics. Therefore, a unified topic creates a
+     * one-to-many relationship with TopicValueBase class.
+     */
 
 
 

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/UnifiedTopic.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/UnifiedTopic.java
@@ -1,0 +1,55 @@
+package org.texttechnologylab.models.topic;
+
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.texttechnologylab.models.UIMAAnnotation;
+import org.texttechnologylab.models.corpus.Document;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+@Table(name = "unified_topic")
+public class UnifiedTopic extends UIMAAnnotation {
+
+
+
+    @OneToMany(mappedBy = "unifiedTopic", cascade = CascadeType.ALL, fetch=FetchType.EAGER)
+    @Fetch(value = FetchMode.SUBSELECT)
+    private List<TopicValueBase> topics;
+
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false, cascade = {CascadeType.PERSIST, CascadeType.MERGE})
+    @JoinColumn(name = "document_id", nullable = false)
+    private Document document;
+
+
+    public UnifiedTopic() {
+        super(-1, -1);
+    }
+
+    public UnifiedTopic(int begin, int end) {
+        super(begin, end);
+    }
+
+    public UnifiedTopic(int begin, int end, String coveredText) {
+        super(begin, end);
+        setCoveredText(coveredText);
+    }
+
+    public List<TopicValueBase> getTopics() {
+        return topics;
+    }
+
+    public void setTopics(List<TopicValueBase> topics) {
+        this.topics = topics;
+    }
+    public Document getDocument() {
+        return document;
+    }
+
+    public void setDocument(Document document) {
+        this.document = document;
+    }
+
+}

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/UnifiedTopic.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/UnifiedTopic.java
@@ -9,7 +9,7 @@ import javax.persistence.*;
 import java.util.List;
 
 @Entity
-@Table(name = "unified_topic")
+@Table(name = "unifiedtopic")
 public class UnifiedTopic extends UIMAAnnotation {
 
 

--- a/uce.portal/uce.common/src/main/resources/corpusConfig.json
+++ b/uce.portal/uce.common/src/main/resources/corpusConfig.json
@@ -25,7 +25,8 @@
     },
     "time": false,
     "wikipediaLink": false,
-    "completeNegation": false
+    "completeNegation": false,
+    "unifiedTopic": false
 
   },
   "other": {


### PR DESCRIPTION
This PR adds four model classes which will be used to access the [UnifiedTopic](https://github.com/texttechnologylab/UIMATypeSystem/blob/uima-3/src/main/resources/desc/type/TypeSystemUnifiedTopic.xml) annotations. 

**Note**: This requires UIMATypeSystem version [db0339b624](https://github.com/texttechnologylab/UIMATypeSystem/commit/da7037671ba86775e19d37e2c8775ab5253e6100) or above.