### PR TITLE
Toggling More/less button in search results with more than one snippets

### DIFF
--- a/uce.portal/resources/templates/js/search.js
+++ b/uce.portal/resources/templates/js/search.js
@@ -327,7 +327,15 @@ $('body').on('click', '.document-card .snippets-container .toggle-snippets-btn',
     const $snippets = $(this).closest('.snippets-container').find('.snippet-content');
     $snippets.each(function(){
         if($(this).data('id') !== 0) $(this).toggle();
-    })
+    });
+    if ($(this).parent().find(".snippet-content").length > 1) {
+        var style = $(this).parent().find(".snippet-content[data-id='1']")[0].getAttribute("style");;
+        const regex =  /display: none;/;
+        var found = style.match(regex);
+        $(this).text((found ? "${languageResource.get('more')} " : "${languageResource.get('less')} " ));
+        $(this).append('<i class="ml-1 fas fa-file-alt" aria-hidden="true"></i>');
+    };
+
 })
 
 let currentFocusedDocumentId = -1;

--- a/uce.portal/uce.web/src/main/resources/languageTranslations.json
+++ b/uce.portal/uce.web/src/main/resources/languageTranslations.json
@@ -191,6 +191,10 @@
     "de-DE": "Mehr dazu",
     "en-EN": "More"
   },
+  "less": {
+    "de-DE": "Weniger dazu",
+    "en-EN": "Less"
+  },
   "highlight": {
     "de-DE": "Hervorheben",
     "en-EN": "Highlight"


### PR DESCRIPTION
As discussed with Kevin Bönisch, here is the Button-toggler for the snippet view in the search results.

"More" becomes "Less", when expanded & "Mehr davon" becomes "Weniger davon"