### PR TITLE
add TopicValueBase wiki model and UI

### DIFF
--- a/uce.portal/resources/templates/css/wiki.css
+++ b/uce.portal/resources/templates/css/wiki.css
@@ -550,7 +550,7 @@
 /* Topic Value Base Wiki Page */
 .wiki-page .topic-value-base-spans {
     line-height: 1.5;
-    background-color: #f4f4f4;
+    background-color: #fafafa;
     margin: 8px 0;
     padding: 10px;
     border-radius: 5px;
@@ -558,6 +558,24 @@
     transition: all 0.3s ease;
 }
 
+.wiki-page .topic-value-base-spans p {
+    font-size: 16px;
+    color: #27272a;
+    margin-bottom: 6px;
+}
+
+.wiki-page .topic-value-base-spans .topic-metadata {
+    font-size: 14px;
+    color: #71717a;
+    margin-top: 4px;
+}
+
+.wiki-page .highlighted-word {
+    background-color: rgba(255, 255, 0, 0.4);
+    padding: 2px 0;
+    border-radius: 3px;
+    font-weight: bold;
+}
 
 .wiki-page .topic-value-base-spans:hover {
     background-color: #e0e0e0;

--- a/uce.portal/resources/templates/css/wiki.css
+++ b/uce.portal/resources/templates/css/wiki.css
@@ -546,3 +546,29 @@
     border-color: gray;
     cursor: pointer;
 }
+
+/* Topic Value Base Wiki Page */
+.wiki-page .topic-value-base-spans {
+    line-height: 1.5;
+    background-color: #f4f4f4;
+    margin: 8px 0;
+    padding: 10px;
+    border-radius: 5px;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+    transition: all 0.3s ease;
+}
+
+
+.wiki-page .topic-value-base-spans:hover {
+    background-color: #e0e0e0;
+    transform: translateY(-2px);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+}
+
+.wiki-page .topic-value-base-spans:nth-child(odd) {
+    border-left: 5px solid #007bff;
+}
+
+.wiki-page .topic-value-base-spans:nth-child(even) {
+    border-left: 5px solid #28a745;
+}

--- a/uce.portal/resources/templates/search/components/documentCardContent.ftl
+++ b/uce.portal/resources/templates/search/components/documentCardContent.ftl
@@ -86,6 +86,15 @@
                 #${document.getDocumentKeywordDistribution().getYakeTopicThree()}
             </label>
         </#if>
+        <#if document.getDocumentUnifiedTopicDistribution(3)?has_content>
+            <#list document.getDocumentUnifiedTopicDistribution(3) as topic>
+                <label data-wid="${topic.getWikiId()}"
+                       data-wcovered="${topic.getValue()}"
+                       class="add-wiki-logo open-wiki-page">
+                    ${topic.getValue()}
+                </label>
+            </#list>
+        </#if>
     </div>
 </div>
 

--- a/uce.portal/resources/templates/wiki/pages/topicValueBaseAnnotationPage.ftl
+++ b/uce.portal/resources/templates/wiki/pages/topicValueBaseAnnotationPage.ftl
@@ -22,12 +22,20 @@
         </div>
     </div>
 
-    <#list vm.getMatchingUnifiedTopics() as topic>
-        <div class="topic-value-base-spans">${topic.getCoveredText()}</div>
+    <#list vm.getMatchingTopics() as topic>
+        <div class="topic-value-base-spans">
+            <p>
+                ${vm.getHighlightedText(topic)}
+            </p>
+            <div class="topic-metadata">
+                Doc ID: ${topic.getDocument().getId()} |
+                <#if vm.hasScore()>
+                    Relevance: ${vm.getTopic().getScore()?string("0.00")}
+                <#else>
+                    Relevance: N/A
+                </#if>
+            </div>
+        </div>
     </#list>
-
-
-
-
 
 </div>

--- a/uce.portal/resources/templates/wiki/pages/topicValueBaseAnnotationPage.ftl
+++ b/uce.portal/resources/templates/wiki/pages/topicValueBaseAnnotationPage.ftl
@@ -1,0 +1,33 @@
+<div class="wiki-page container">
+
+    <!-- breadcrumbs -->
+    <div class="mb-3">
+        <#include "*/wiki/components/breadcrumbs.ftl">
+    </div>
+
+    <!-- metadata header -->
+    <div>
+        <#include "*/wiki/components/metadata.ftl">
+    </div>
+
+    <hr class="mt-2 mb-4"/>
+
+
+    <!-- the document this is from -->
+    <div class="mt-4 mb-3 w-100 p-0 m-0 justify-content-center flexed align-items-start">
+        <div class="document-card w-100">
+            <#assign document = vm.getDocument()>
+            <#assign searchId = "">
+            <#include '*/search/components/documentCardContent.ftl' >
+        </div>
+    </div>
+
+    <#list vm.getMatchingUnifiedTopics() as topic>
+        <div class="topic-value-base-spans">${topic.getCoveredText()}</div>
+    </#list>
+
+
+
+
+
+</div>

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/corpus/Document.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/corpus/Document.java
@@ -409,4 +409,36 @@ public class Document extends ModelBase implements WikiModel {
     public void setUnifiedTopics(List<UnifiedTopic> unifiedTopics) {
         this.unifiedTopics = unifiedTopics;
     }
+
+    public List<TopicValueBase> getDocumentUnifiedTopicDistribution(Integer topN) {
+        List<TopicValueBaseWithScore> scoredTopics = new ArrayList<>();
+        List<TopicValueBase> unscoredTopics = new ArrayList<>();
+
+        // Separate scored and unscored topics using getRepresentativeTopic()
+        for (UnifiedTopic unifiedTopic : unifiedTopics) {
+            TopicValueBase representativeTopic = unifiedTopic.getRepresentativeTopic();
+
+            if (representativeTopic != null) {
+                if (representativeTopic instanceof TopicValueBaseWithScore) {
+                    scoredTopics.add((TopicValueBaseWithScore) representativeTopic);
+                } else {
+                    unscoredTopics.add(representativeTopic);
+                }
+            }
+        }
+
+        // If scored topics exist, sort and return topN
+        if (!scoredTopics.isEmpty()) {
+            return scoredTopics.stream()
+                    .sorted(Comparator.comparingDouble(TopicValueBaseWithScore::getScore).reversed())
+                    .limit(topN)
+                    .collect(Collectors.toList());
+        }
+
+        // If no scored topics, return topN unscored topics
+        return unscoredTopics.stream()
+                .limit(topN)
+                .collect(Collectors.toList());
+    }
+
 }

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicValueBase.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/TopicValueBase.java
@@ -1,6 +1,7 @@
 package org.texttechnologylab.models.topic;
 
 import org.texttechnologylab.models.UIMAAnnotation;
+import org.texttechnologylab.models.WikiModel;
 import org.texttechnologylab.models.corpus.Document;
 
 import javax.persistence.*;
@@ -8,7 +9,8 @@ import java.util.List;
 
 @Entity
 @Table(name = "topicvaluebase")
-public class TopicValueBase extends UIMAAnnotation {
+@Inheritance(strategy = InheritanceType.JOINED)
+public class TopicValueBase extends UIMAAnnotation implements WikiModel {
     /***
      * TopicValueBase class can be used to represent a topic with a label in a document. It also allows to represent a
      * topic with a list of word. Therefore, TopicValueBase class has one-to-many relationship with TopicWord class.
@@ -76,4 +78,8 @@ public class TopicValueBase extends UIMAAnnotation {
         this.document = document;
     }
 
+    @Override
+    public String getWikiId() {
+        return "TVB" + "-" + this.getId();
+    }
 }

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/UnifiedTopic.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/topic/UnifiedTopic.java
@@ -47,6 +47,17 @@ public class UnifiedTopic extends UIMAAnnotation implements WikiModel {
         return topics;
     }
 
+    public List<TopicValueBase> getOrderedTopics(String order) {
+        if (topics != null) {
+            topics.sort((t1, t2) -> {
+                double score1 = (t1 instanceof TopicValueBaseWithScore) ? ((TopicValueBaseWithScore) t1).getScore() : 0;
+                double score2 = (t2 instanceof TopicValueBaseWithScore) ? ((TopicValueBaseWithScore) t2).getScore() : 0;
+                return order.equals("asc") ? Double.compare(score1, score2) : Double.compare(score2, score1);
+            });
+        }
+        return topics;
+    }
+
     public void setTopics(List<TopicValueBase> topics) {
         this.topics = topics;
     }
@@ -56,6 +67,16 @@ public class UnifiedTopic extends UIMAAnnotation implements WikiModel {
 
     public void setDocument(Document document) {
         this.document = document;
+    }
+
+    public TopicValueBase getRepresentativeTopic() {
+        if (topics == null || topics.isEmpty()) {
+            return null;
+        }
+
+        // Get topics ordered by score in descending order and return the first one
+        List<TopicValueBase> orderedTopics = getOrderedTopics("desc");
+        return orderedTopics.get(0);
     }
 
     @Override

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/viewModels/wiki/TopicValueBaseWikiPageViewModel.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/viewModels/wiki/TopicValueBaseWikiPageViewModel.java
@@ -2,14 +2,20 @@ package org.texttechnologylab.models.viewModels.wiki;
 
 import org.texttechnologylab.models.corpus.Document;
 import org.texttechnologylab.models.topic.TopicValueBase;
+import org.texttechnologylab.models.topic.TopicValueBaseWithScore;
+import org.texttechnologylab.models.topic.TopicWord;
 import org.texttechnologylab.models.topic.UnifiedTopic;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 public class TopicValueBaseWikiPageViewModel extends AnnotationWikiPageViewModel {
 
     private TopicValueBase topicValueBase;
-    private List<UnifiedTopic> matchingUnifiedTopics;
+    private List<TopicValueBase> matchingTopicValueBases;
 
     public TopicValueBase getTopic() {
         return topicValueBase;
@@ -19,7 +25,7 @@ public class TopicValueBaseWikiPageViewModel extends AnnotationWikiPageViewModel
         this.topicValueBase = topic;
     }
 
-    public List<UnifiedTopic> getMatchingUnifiedTopics() {
+    public List<TopicValueBase> getMatchingTopics() {
             if (topicValueBase != null) {
                 Document document = this.getDocument();
 
@@ -28,16 +34,115 @@ public class TopicValueBaseWikiPageViewModel extends AnnotationWikiPageViewModel
 
                     List<UnifiedTopic> unifiedTopics = document.getUnifiedTopics();
 
-                    matchingUnifiedTopics = unifiedTopics.stream()
-                            .filter(unifiedTopic -> unifiedTopic.getTopics().stream()
-                                    .anyMatch(topic -> topic.getValue().equals(topicValue)))
+                    // Collect all TopicValueBase objects that match the value
+                    matchingTopicValueBases = unifiedTopics.stream()
+                            .flatMap(unifiedTopic -> unifiedTopic.getTopics().stream())
+                            .filter(topic -> topic.getValue().equals(topicValue))
                             .toList();
-                    return matchingUnifiedTopics;
+                    return matchingTopicValueBases;
                 }
         }
         return null;
     }
 
+    public boolean hasScore(){
+        return topicValueBase instanceof TopicValueBaseWithScore;
+    }
 
 
+
+    public String getHighlightedText(TopicValueBase topic) {
+        /**
+         * Generates HTML with highlighted topic words for a given TopicValueBase
+         * Words are highlighted with colors based on their probability scores:
+         * - Red to green gradient for words with scores (normalized between min and max)
+         *   Red indicates lower scores, green indicates higher scores
+         * - Gray for words without scores
+         */
+        if (topic == null || topic.getWords() == null || topic.getWords().isEmpty()) {
+            return topic != null ? topic.getCoveredText() : "";
+        }
+
+        String coveredText = topic.getCoveredText();
+        if (coveredText == null || coveredText.isEmpty()) {
+            return "";
+        }
+
+        int topicBegin = topic.getBegin();
+
+        double minProbability = Double.MAX_VALUE;
+        double maxProbability = Double.MIN_VALUE;
+        boolean hasScores = false;
+
+        for (TopicWord word : topic.getWords()) {
+            double probability = word.getProbability();
+            if (probability > 0) {
+                hasScores = true;
+                minProbability = Math.min(minProbability, probability);
+                maxProbability = Math.max(maxProbability, probability);
+            }
+        }
+
+        Map<Integer, String> startTags = new TreeMap<>();
+        Map<Integer, String> endTags = new TreeMap<>();
+
+        for (TopicWord word : topic.getWords()) {
+            int relativeBegin = word.getBegin() - topicBegin;
+            int relativeEnd = word.getEnd() - topicBegin;
+
+            if (relativeBegin >= 0 && relativeEnd <= coveredText.length()) {
+                String style;
+                double probability = word.getProbability();
+
+                if (hasScores && probability > 0) {
+                    double normalizedScore = (probability - minProbability) / (maxProbability - minProbability);
+
+                    int red = (int) ((1 - normalizedScore) * 255);
+                    int green = (int) (normalizedScore * 255);
+                    int blue = 0;
+
+                    style = String.format("background-color: rgba(%d, %d, %d, 0.4); color: black;", red, green, blue);
+                } else {
+                    style = "background-color: rgba(150, 150, 150, 0.4); color: black;";
+                }
+
+                startTags.put(relativeBegin, "<span class='highlighted-word' style='" + style + "'>");
+                endTags.put(relativeEnd, "</span>");
+            }
+        }
+
+        if (startTags.isEmpty()) {
+            return coveredText;
+        }
+
+        StringBuilder result = new StringBuilder();
+        int currentPos = 0;
+
+        List<Integer> allPositions = new ArrayList<>();
+        allPositions.addAll(startTags.keySet());
+        allPositions.addAll(endTags.keySet());
+        allPositions.sort(Comparator.naturalOrder());
+
+        for (int pos : allPositions) {
+            if (pos > currentPos) {
+                result.append(coveredText.substring(currentPos, pos));
+            }
+
+            if (endTags.containsKey(pos)) {
+                result.append(endTags.get(pos));
+            }
+
+            if (startTags.containsKey(pos)) {
+                result.append(startTags.get(pos));
+            }
+
+            currentPos = pos;
+        }
+
+        if (currentPos < coveredText.length()) {
+            result.append(coveredText.substring(currentPos));
+        }
+
+        return result.toString();
+    }
 }

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/viewModels/wiki/TopicValueBaseWikiPageViewModel.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/viewModels/wiki/TopicValueBaseWikiPageViewModel.java
@@ -1,0 +1,43 @@
+package org.texttechnologylab.models.viewModels.wiki;
+
+import org.texttechnologylab.models.corpus.Document;
+import org.texttechnologylab.models.topic.TopicValueBase;
+import org.texttechnologylab.models.topic.UnifiedTopic;
+
+import java.util.List;
+
+public class TopicValueBaseWikiPageViewModel extends AnnotationWikiPageViewModel {
+
+    private TopicValueBase topicValueBase;
+    private List<UnifiedTopic> matchingUnifiedTopics;
+
+    public TopicValueBase getTopic() {
+        return topicValueBase;
+    }
+
+    public void setTopic(TopicValueBase topic) {
+        this.topicValueBase = topic;
+    }
+
+    public List<UnifiedTopic> getMatchingUnifiedTopics() {
+            if (topicValueBase != null) {
+                Document document = this.getDocument();
+
+                if (document != null) {
+                    String topicValue = topicValueBase.getValue();
+
+                    List<UnifiedTopic> unifiedTopics = document.getUnifiedTopics();
+
+                    matchingUnifiedTopics = unifiedTopics.stream()
+                            .filter(unifiedTopic -> unifiedTopic.getTopics().stream()
+                                    .anyMatch(topic -> topic.getValue().equals(topicValue)))
+                            .toList();
+                    return matchingUnifiedTopics;
+                }
+        }
+        return null;
+    }
+
+
+
+}

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/PostgresqlDataInterface_Impl.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/PostgresqlDataInterface_Impl.java
@@ -19,6 +19,7 @@ import org.texttechnologylab.models.imp.ImportLog;
 import org.texttechnologylab.models.imp.UCEImport;
 import org.texttechnologylab.models.negation.CompleteNegation;
 import org.texttechnologylab.models.search.*;
+import org.texttechnologylab.models.topic.TopicValueBase;
 import org.texttechnologylab.models.topic.UnifiedTopic;
 import org.texttechnologylab.models.util.HealthStatus;
 import org.texttechnologylab.utils.SystemStatus;
@@ -744,6 +745,9 @@ public class PostgresqlDataInterface_Impl implements DataInterface {
             Hibernate.initialize(neg);
             return neg;
         });
+    }
+    public TopicValueBase getTopicValueBaseById(long id) throws DatabaseOperationException {
+        return executeOperationSafely((session) -> session.get(TopicValueBase.class, id));
     }
 
     public UnifiedTopic getUnifiedTopicById(long id) throws DatabaseOperationException {

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/WikiService.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/WikiService.java
@@ -95,7 +95,25 @@ public class WikiService {
         viewModel.setCorpus(db.getCorpusById(viewModel.getDocument().getCorpusId()).getViewModel());
         viewModel.setCoveredText(coveredText);
         viewModel.setAnnotationType("UnifiedTopic");
-        viewModel.setTopics(unifiedTopic.getTopics());
+        viewModel.setTopics(unifiedTopic.getOrderedTopics("desc"));
+
+
+        return viewModel;
+    }
+
+    /**
+     * Gets a TopicValueBaseWikiPageViewModel to render a Wikipage for that annotation
+     */
+    public TopicValueBaseWikiPageViewModel buildTopicValueBaseWikiPageViewModel(long id, String coveredText) throws DatabaseOperationException {
+        var viewModel = new TopicValueBaseWikiPageViewModel();
+        var topicValueBase = db.getTopicValueBaseById(id);
+        viewModel.setWikiModel(topicValueBase);
+        viewModel.setDocument(db.getDocumentById(topicValueBase.getDocument().getId()));
+        viewModel.setCorpus(db.getCorpusById(viewModel.getDocument().getCorpusId()).getViewModel());
+        viewModel.setCoveredText(coveredText);
+        viewModel.setAnnotationType("TopicValueBase");
+        viewModel.setTopic(topicValueBase);
+
 
         return viewModel;
     }

--- a/uce.portal/uce.web/src/main/java/org/texttechnologylab/routes/WikiApi.java
+++ b/uce.portal/uce.web/src/main/java/org/texttechnologylab/routes/WikiApi.java
@@ -167,6 +167,9 @@ public class WikiApi {
             } else if (type.startsWith("UT")) {
                 model.put("vm", wikiService.buildUnifiedTopicWikiPageViewModel(id, coveredText));
                 renderView = "/wiki/pages/unifiedTopicAnnotationPage.ftl";
+            } else if (type.startsWith("TVB")) {
+                model.put("vm", wikiService.buildTopicValueBaseWikiPageViewModel(id, coveredText));
+                renderView = "/wiki/pages/topicValueBaseAnnotationPage.ftl";
             } else {
                 // The type part of the wikiId was unknown. Throw an error.
                 logger.warn("Someone tried to query a wiki page of a type that does not exist in UCE. This shouldn't happen.");


### PR DESCRIPTION
This PR add TopicValueBase wiki model and its UI. This allows us to get document level topics and visualize it in the document card. Currently, we visualize top three topics but number of topics can be changed using the parameter `topN`.