### PR TITLE
snippet rendering fix

### DIFF
--- a/uce.portal/resources/templates/css/site.css
+++ b/uce.portal/resources/templates/css/site.css
@@ -1,7 +1,7 @@
 :root {
     /* Variables prime and secondary MUST ALWAYS be in line 3 and 4! */
-    --prime: #5c7a17;
-    --secondary: darkgreen;
+    --prime: #00618f;
+    --secondary: rgba(35, 35, 35, 1);
     --gold: rgba(255, 165, 0, 1);
     --dark: rgba(38, 38, 38, 1);
     --default: rgb(245, 245, 247, 1);
@@ -126,6 +126,11 @@ nav .selected-nav-btn.text::before {
 
 .small-font {
     font-size: small;
+}
+
+.small-font.text.font-italic.mr-2.word-break-word {
+    font-family: "Courier New", Courier, monospace;
+    font-style: normal;
 }
 
 .medium-font {

--- a/uce.portal/resources/templates/search/components/documentCardContent.ftl
+++ b/uce.portal/resources/templates/search/components/documentCardContent.ftl
@@ -182,6 +182,7 @@
             </#if>
         </#macro>
 
+        <#--
         <#macro renderFallback document>
             <#if document?has_content>
                 <div class="snippet-content position-relative">
@@ -189,6 +190,32 @@
                         ${document.getFullTextSnippet(85)}...
                     </div>
                 </div>
+            </#if>
+        </#macro>
+        -->
+        <#macro renderFallback document>
+            <#if document?has_content>
+                <#if mainAnno??>
+                    <#if offsetList??>
+                        <div class="snippet-content position-relative">
+                            <div class="small-font text font-italic mr-2 word-break-word">
+                                ${document.getFullTextSnippetOffsetList(offsetList)}...
+                            </div>
+                        </div>
+                    <#else>
+                        <div class="snippet-content position-relative">
+                            <div class="small-font text font-italic mr-2 word-break-word">
+                                ${document.getFullTextSnippetAnnotationOffset(mainAnno)}...
+                            </div>
+                        </div>
+                    </#if>
+                <#else>
+                    <div class="snippet-content position-relative">
+                        <div class="small-font text font-italic mr-2 word-break-word">
+                            ${document.getFullTextSnippet(85)}...
+                        </div>
+                    </div>
+                </#if>
             </#if>
         </#macro>
 
@@ -210,6 +237,8 @@
             <@renderFallback document/>
         </#if>
 
+
+        <#--
         <#macro renderFallback document>
             <#if document?has_content>
                 <#if mainAnno??>
@@ -235,6 +264,7 @@
                 </#if>
             </#if>
         </#macro>
+        -->
 
         <!-- metadata if it exists (and its not reduced view) -->
         <#if !isReducedView && document.getUceMetadataWithoutJson()?size gt 0>

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/PostgresqlDataInterface_Impl.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/PostgresqlDataInterface_Impl.java
@@ -896,6 +896,12 @@ public class PostgresqlDataInterface_Impl implements DataInterface {
                                     }.getType());
                             foundSnippets.put(idx, pageSnippet.getFirst());
                         }
+                        foundSnippets.forEach((key, snippetList) -> {
+                            for (PageSnippet snippet : snippetList) {
+                                // Modify the value (example: changing content)
+                                snippet.setSnippet(snippet.getSnippet().replaceAll("\n", "<br/>").replaceAll(" ", "&nbsp;"));
+                            }
+                        });
                         search.setSearchSnippets(foundSnippets);
 
                         // And the ranks of each document.


### PR DESCRIPTION
- added whitespace and linke break replacement for snippets in the default search
- changed font for documentcard snippet rendering
- fixed double occurrence of renderfallback in documentCardContent.ftl