### PR TITLE
Add corpus level topic visualisation

### DIFF
--- a/database/13_corpusTopicDist.sql
+++ b/database/13_corpusTopicDist.sql
@@ -1,0 +1,20 @@
+CREATE OR REPLACE FUNCTION get_normalized_topic_scores(corpusid BIGINT)
+RETURNS TABLE(topic VARCHAR(255), normalized_score DOUBLE PRECISION) AS $$
+BEGIN
+RETURN QUERY
+SELECT
+    subquery.topiclabel,
+    avg_thetadt / SUM(avg_thetadt) OVER () AS normalized_score
+FROM (
+         SELECT
+             topiclabel AS topiclabel,
+             AVG(thetadt) AS avg_thetadt
+         FROM documenttopicsraw
+         WHERE document_id IN (
+             SELECT id FROM document WHERE document.corpusid = get_normalized_topic_scores.corpusid
+         )
+         GROUP BY topiclabel
+     ) subquery
+ORDER BY normalized_score DESC;
+END;
+$$ LANGUAGE plpgsql;

--- a/uce.portal/resources/templates/css/wiki.css
+++ b/uce.portal/resources/templates/css/wiki.css
@@ -627,3 +627,7 @@
     pointer-events: none;
     white-space: nowrap;
 }
+#corpus-topic-distribution-container {
+    height:500px;
+    width:100%
+}

--- a/uce.portal/resources/templates/js/graphViz.js
+++ b/uce.portal/resources/templates/js/graphViz.js
@@ -54,7 +54,7 @@ var GraphVizHandler = (function () {
         return jsChart;
     }
 
-    GraphVizHandler.prototype.createWordCloud = async function (target, title, data) {
+    GraphVizHandler.prototype.createWordCloud = async function (target, title, wordData) {
 
         if (!wordData || !Array.isArray(wordData) || wordData.length === 0) {
             console.error('Invalid data provided to drawTopicWordCloud:', wordData);
@@ -121,9 +121,9 @@ function getNewGraphVizHandler() {
 }
 
 function getColorForWeight(weight) {
-    const r = Math.floor(50 + (weight * 205));
-    const g = Math.floor(50 + ((1 - weight) * 150));
-    const b = Math.floor(150 + ((1 - weight) * 105));
+    const r = Math.floor(255 * (1 - weight));
+    const g = Math.floor(200 * weight);
+    const b = 0;
     return "rgb(" + r + ", " + g + ", " + b + ")";
 }
 

--- a/uce.portal/resources/templates/wiki/pages/corpusPage.ftl
+++ b/uce.portal/resources/templates/wiki/pages/corpusPage.ftl
@@ -70,6 +70,17 @@
         </div>
     </div>
 
+    <div class="text-center mb-3">
+        <h6 class="mb-3">Top 20 words from Corpus</h6>
+        <!-- Topic Word Cloud -->
+        <div class="col-md-6 mx-auto">
+            <div id="topicWordCloud"></div>
+        </div>
+    </div>
+
+    <div id="topic-distribution-container" style="height: 500px; width:100%"></div>
+
+
     <!-- Documents -->
     <!--<h5 class="text-center">Documents</h5>
     <div class="group-box card-shadow bg-lightgray">
@@ -84,6 +95,51 @@
     $(document).ready(function () {
         // After that, we load documentsListView
         //loadCorpusDocuments(${vm.getCorpus().getCorpus().getId()}, $('.wiki-page .corpus-documents-list-include'));
+
+        var wordData = [
+            <#if vm.getNormalizedTopicWords()?? && vm.getNormalizedTopicWords()?has_content>
+            <#list vm.getNormalizedTopicWords() as term>
+            {
+                "term": "${term.getWord()?js_string}",
+                "weight": ${term.getProbability()?c}
+            }<#if term_has_next>, </#if>
+            </#list>
+            </#if>
+        ];
+
+        var topicDistData = {
+            "labels": [
+                <#if vm.getTopicDistributions()?? && vm.getTopicDistributions()?has_content>
+                <#list vm.getTopicDistributions()?keys as topicLabel>
+                "${topicLabel?js_string}"<#if topicLabel_has_next>, </#if>
+                </#list>
+                </#if>
+            ],
+            "data": [
+                <#if vm.getTopicDistributions()?? && vm.getTopicDistributions()?has_content>
+                <#list vm.getTopicDistributions()?values as weight>
+                ${weight?c}<#if weight_has_next>, </#if>
+                </#list>
+                </#if>
+            ],
+            "labelName": "Topic Distribution"
+        };
+
+        window.graphVizHandler.createWordCloud(document.getElementById('topicWordCloud'), wordData);
+
+        window.graphVizHandler.createBasicChart(document.getElementById('topic-distribution-container'),
+            'Topic Distribution in Corpus',
+            topicDistData,
+            'pie'
+        );
+
+        window.graphVizHandler.createWordCloud(document.getElementById('topicWordCloud'), 'Word Cloud', wordData);
+
+        window.graphVizHandler.createBasicChart(document.getElementById('topic-distribution-container'),
+            'Top 20 topics from Corpus',
+            topicDistData,
+            'bar',
+        );
     })
 </script>
 

--- a/uce.portal/resources/templates/wiki/pages/corpusPage.ftl
+++ b/uce.portal/resources/templates/wiki/pages/corpusPage.ftl
@@ -125,20 +125,12 @@
             "labelName": "Topic Distribution"
         };
 
-        window.graphVizHandler.createWordCloud(document.getElementById('topicWordCloud'), wordData);
+        window.graphVizHandler.createWordCloud(document.getElementById('topicWordCloud'), 'Word Cloud', wordData);
 
         window.graphVizHandler.createBasicChart(document.getElementById('topic-distribution-container'),
             'Topic Distribution in Corpus',
             topicDistData,
             'pie'
-        );
-
-        window.graphVizHandler.createWordCloud(document.getElementById('topicWordCloud'), 'Word Cloud', wordData);
-
-        window.graphVizHandler.createBasicChart(document.getElementById('topic-distribution-container'),
-            'Top 20 topics from Corpus',
-            topicDistData,
-            'bar',
         );
     })
 </script>

--- a/uce.portal/resources/templates/wiki/pages/corpusPage.ftl
+++ b/uce.portal/resources/templates/wiki/pages/corpusPage.ftl
@@ -71,14 +71,14 @@
     </div>
 
     <div class="text-center mb-3">
-        <h6 class="mb-3">Top 20 words from Corpus</h6>
+        <h6 class="mb-3">${languageResource.get("corpusWords")}</h6>
         <!-- Topic Word Cloud -->
         <div class="col-md-6 mx-auto">
             <div id="topicWordCloud"></div>
         </div>
     </div>
 
-    <div id="topic-distribution-container" style="height: 500px; width:100%"></div>
+    <div id="corpus-topic-distribution-container"></div>
 
 
     <!-- Documents -->
@@ -127,7 +127,7 @@
 
         window.graphVizHandler.createWordCloud(document.getElementById('topicWordCloud'), 'Word Cloud', wordData);
 
-        window.graphVizHandler.createBasicChart(document.getElementById('topic-distribution-container'),
+        window.graphVizHandler.createBasicChart(document.getElementById('corpus-topic-distribution-container'),
             'Topic Distribution in Corpus',
             topicDistData,
             'pie'

--- a/uce.portal/resources/templates/wiki/pages/topicPage.ftl
+++ b/uce.portal/resources/templates/wiki/pages/topicPage.ftl
@@ -91,7 +91,7 @@
         'polarArea',
     );
 
-    window.graphVizHandler.createWordCloud(document.getElementById('topicWordCloud'), wordData);
+    window.graphVizHandler.createWordCloud(document.getElementById('topicWordCloud'), 'Word Cloud', wordData);
 
 
 

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/viewModels/wiki/CorpusWikiPageViewModel.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/viewModels/wiki/CorpusWikiPageViewModel.java
@@ -2,15 +2,36 @@ package org.texttechnologylab.models.viewModels.wiki;
 
 import org.texttechnologylab.models.WikiModel;
 import org.texttechnologylab.models.corpus.UCEMetadataValueType;
+import org.texttechnologylab.models.topic.TopicWord;
 import org.texttechnologylab.models.viewModels.CorpusViewModel;
 import org.texttechnologylab.models.viewModels.JsonViewModel;
 import org.texttechnologylab.utils.JsonBeautifier;
 
 import java.util.List;
+import java.util.Map;
 
-public class CorpusWikiPageViewModel extends AnnotationWikiPageViewModel{
+public class CorpusWikiPageViewModel extends AnnotationWikiPageViewModel {
 
     private int documentsCount;
+    private List<TopicWord> normalizedTopicWords;
+
+    private Map<String, Double> topicDistributions;
+
+    public Map<String, Double> getTopicDistributions() {
+        return topicDistributions;
+    }
+
+    public void setTopicDistributions(Map<String, Double> topicDistributions) {
+        this.topicDistributions = topicDistributions;
+    }
+
+    public List<TopicWord> getNormalizedTopicWords() {
+        return normalizedTopicWords;
+    }
+
+    public void setNormalizedTopicWords(List<TopicWord> normalizedTopicWords) {
+        this.normalizedTopicWords = normalizedTopicWords;
+    }
 
     public int getDocumentsCount() {
         return documentsCount;
@@ -24,5 +45,6 @@ public class CorpusWikiPageViewModel extends AnnotationWikiPageViewModel{
         var beautifier = new JsonBeautifier();
         return beautifier.parseJsonToViewModel(getCorpus().getCorpus().getCorpusJsonConfig());
     }
+
 
 }

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/WikiService.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/WikiService.java
@@ -30,12 +30,8 @@ public class WikiService {
         viewModel.setAnnotationType("Corpus");
         viewModel.setCorpus(corpus.getViewModel());
         viewModel.setDocumentsCount(db.countDocumentsInCorpus(corpusId));
-
-        List<TopicWord> normalizedTopicWords = db.getNormalizedTopicWordsForCorpus(corpusId);
-        viewModel.setNormalizedTopicWords(normalizedTopicWords);
-
-        Map<String, Double> topicDistributions = db.getTopNormalizedTopicsByCorpusId(corpusId);
-        viewModel.setTopicDistributions(topicDistributions);
+        viewModel.setNormalizedTopicWords(db.getNormalizedTopicWordsForCorpus(corpusId));
+        viewModel.setTopicDistributions(db.getTopNormalizedTopicsByCorpusId(corpusId));
 
         return viewModel;
     }

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/WikiService.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/WikiService.java
@@ -11,6 +11,7 @@ import org.texttechnologylab.utils.SystemStatus;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 public class WikiService {
     private final PostgresqlDataInterface_Impl db;
@@ -29,6 +30,12 @@ public class WikiService {
         viewModel.setAnnotationType("Corpus");
         viewModel.setCorpus(corpus.getViewModel());
         viewModel.setDocumentsCount(db.countDocumentsInCorpus(corpusId));
+
+        List<TopicWord> normalizedTopicWords = db.getNormalizedTopicWordsForCorpus(corpusId);
+        viewModel.setNormalizedTopicWords(normalizedTopicWords);
+
+        Map<String, Double> topicDistributions = db.getTopNormalizedTopicsByCorpusId(corpusId);
+        viewModel.setTopicDistributions(topicDistributions);
 
         return viewModel;
     }

--- a/uce.portal/uce.web/src/main/resources/languageTranslations.json
+++ b/uce.portal/uce.web/src/main/resources/languageTranslations.json
@@ -366,5 +366,9 @@
   "topics": {
     "de-DE": "Wichtige Themen",
     "en-EN": "Key Topics"
+  },
+  "corpusWords": {
+    "de-DE": "Top 20 Wörter aus dem Korpus",
+    "en-EN": "Top 20 words from Corpus"
   }
 }


### PR DESCRIPTION
This PR updates the Corpus wiki page to include topic-related information. It displays a word cloud summarizing the corpus and shows the distribution of topics across the entire corpus.