### PR TITLE
Topic visualization in document wiki page

### DIFF
--- a/uce.portal/resources/templates/css/wiki.css
+++ b/uce.portal/resources/templates/css/wiki.css
@@ -631,3 +631,14 @@
     height:500px;
     width:100%
 }
+
+#document-topic-distribution-container {
+    height:500px;
+    width:100%;
+    margin-bottom: 10px
+}
+
+#document-similar-documents-container {
+    height:500px;
+    width:100%
+}

--- a/uce.portal/resources/templates/wiki/pages/documentAnnotationPage.ftl
+++ b/uce.portal/resources/templates/wiki/pages/documentAnnotationPage.ftl
@@ -13,6 +13,16 @@
 
     <hr class="mt-2 mb-4"/>
 
+    <div class="mt-3 mb-4">
+        <h6 class="text-dark text-center w-100 mb-2">
+            ${languageResource.get('documentWords')}
+        </h6>
+        <div id="topic-word-cloud" class="col-md-8 mx-auto"></div>
+    </div>
+    <div id="document-topic-distribution-container"></div>
+    <div id="document-similar-documents-container"></div>
+
+
     <!-- the document this is from -->
     <div class="mt-4 mb-2 w-100 p-0 m-0 justify-content-center flexed align-items-start">
         <div class="document-card w-100">
@@ -56,5 +66,62 @@
         const center = $('.wiki-page').data('center');
         const corpusId = $('.wiki-page').data('corpusid');
         window.wikiHandler.addUniverseToDocumentWikiPage(corpusId, center);
+
+        var topicsData = {
+            "labels": [
+                <#list vm.getTopicDistribution() as topic>
+                "${topic[0]?js_string}"<#if topic_has_next>,</#if>
+                </#list>
+            ],
+            "data": [
+                <#list vm.getTopicDistribution() as topic>
+                ${topic[1]?c}<#if topic_has_next>,</#if>
+                </#list>
+            ],
+            "labelName": "Topic Weights"
+        };
+
+        var wordData = [
+            <#list vm.getTopicWords() as wordItem>
+            {
+                "term": "${wordItem.getWord()?js_string}",
+                "weight": ${wordItem.getProbability()?c}
+            }<#if wordItem_has_next>,</#if>
+            </#list>
+        ];
+
+        var similarDocumentsData = {
+            "labels": [
+                <#list vm.getSimilarDocuments() as item>
+                "${item[0]?js_string}"<#if item_has_next>,</#if>
+                </#list>
+            ],
+            "data": [
+                <#list vm.getSimilarDocuments() as item>
+                ${item[1]?c}<#if item_has_next>,</#if>
+                </#list>
+            ],
+            "labelName": "Shared Words"
+        };
+
+        window.graphVizHandler.createBasicChart(
+            document.getElementById('document-topic-distribution-container'),
+            'Topic Distribution',
+            topicsData,
+            'pie'
+        );
+
+        window.graphVizHandler.createWordCloud(
+            document.getElementById('topic-word-cloud'),
+            'Top 20 Topic Words',
+            wordData
+        );
+
+        window.graphVizHandler.createBasicChart(document.getElementById('document-similar-documents-container'),
+            'Similar documents based on shared words',
+            similarDocumentsData,
+            'polarArea',
+        );
+
     })
 </script>

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/viewModels/wiki/DocumentAnnotationWikiPageViewModel.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/viewModels/wiki/DocumentAnnotationWikiPageViewModel.java
@@ -1,12 +1,19 @@
 package org.texttechnologylab.models.viewModels.wiki;
 
 import org.texttechnologylab.models.corpus.UCEMetadata;
+import org.texttechnologylab.models.topic.TopicWord;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class DocumentAnnotationWikiPageViewModel extends AnnotationWikiPageViewModel{
 
     private List<UCEMetadata> uceMetadata;
+    private List<Object[]> topicDistribution;
+    private List<TopicWord> topicWords;
+    private List<Object[]> similarDocuments;
 
     public List<UCEMetadata> getUceMetadata() {
         return uceMetadata;
@@ -14,5 +21,29 @@ public class DocumentAnnotationWikiPageViewModel extends AnnotationWikiPageViewM
 
     public void setUceMetadata(List<UCEMetadata> uceMetadata) {
         this.uceMetadata = uceMetadata;
+    }
+
+    public List<Object[]> getTopicDistribution() {
+        return topicDistribution;
+    }
+
+    public void setTopicDistribution(List<Object[]> topicDistribution) {
+        this.topicDistribution = topicDistribution;
+    }
+
+    public List<TopicWord> getTopicWords() {
+        return topicWords;
+    }
+
+    public void setTopicWords(List<TopicWord> topicWords) {
+        this.topicWords = topicWords;
+    }
+
+    public List<Object[]> getSimilarDocuments() {
+        return similarDocuments;
+    }
+
+    public void setSimilarDocuments(List<Object[]> similarDocuments) {
+        this.similarDocuments = similarDocuments;
     }
 }

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/WikiService.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/WikiService.java
@@ -152,6 +152,10 @@ public class WikiService {
         if(viewModel.getCorpus().getCorpusConfig().getAnnotations().isUceMetadata())
             viewModel.setUceMetadata(db.getUCEMetadataByDocumentId(doc.getId()));
 
+        viewModel.setTopicDistribution(db.getTopTopicsByDocument(doc.getId(), 10));
+        viewModel.setTopicWords(db.getDocumentWordDistribution(doc.getId()));
+        viewModel.setSimilarDocuments(db.getSimilarDocumentbyDocumentId(doc.getId()));
+
         return viewModel;
     }
 

--- a/uce.portal/uce.web/src/main/resources/languageTranslations.json
+++ b/uce.portal/uce.web/src/main/resources/languageTranslations.json
@@ -370,5 +370,9 @@
   "corpusWords": {
     "de-DE": "Top 20 Wörter aus dem Korpus",
     "en-EN": "Top 20 words from Corpus"
+  },
+  "documentWords": {
+    "de-DE": "Top 20 Wörter aus dem Dokument",
+    "en-EN": "Top 20 words from document"
   }
 }


### PR DESCRIPTION
This PR visualize topic information in document wiki page. It adds wordcloud based on the normalized topic words. It also adds topic distribution of the given document and the documents which are similar to the given document based on shared topic words.