### PR TITLE
Fix Visualizations

### DIFF
--- a/uce.portal/resources/templates/corpus/corpusInspector.ftl
+++ b/uce.portal/resources/templates/corpus/corpusInspector.ftl
@@ -37,56 +37,20 @@
         </div>
     </div>
 
-    <!-- corpus content with tabs -->
-    <div class="corpus-content col-md-8 w-100 m-0 p-0 border-left position-relative">
+    <!-- corpus documents -->
+    <div class="col-md-8 w-100 m-0 p-0 border-left position-relative">
         <div class="documents-list-header card-shadow bg-default">
-            <div class="flexed w-100 justify-content-end mb-2">
-                <a class="clickable color-prime mb-0 text small" onclick="navigateToView('search')">
+            <div class="flexed w-100 justify-content-between pl-3 pr-3">
+                <h6 class="mb-0 mr-1">${languageResource.get("corpusDocuments")}</h6>
+                <a class="clickable color-prime mb-0 text small ml-1" onclick="navigateToView('search')">
                     <i class="fas fa-search mr-1"></i> ${languageResource.get("callForSearch")}
                 </a>
             </div>
-            <div class="mtabs">
-                <btn class="selected-tab color-prime" data-id="documents">${languageResource.get("corpusDocuments")}</btn>
-                <btn class="color-prime" data-id="thematic">Corpus Thematic Landscape</btn>
-            </div>
         </div>
-        <div class="views">
-            <!-- Documents tab content -->
-            <div class="mview" data-id="documents">
-                <div class="corpus-documents-list-include w-100 position-relative p-3">
-                    <div class="simple-loader"><h5 class="mb-0 text">Loading...</h5></div>
-                </div>
-            </div>
-            <!-- Thematic Landscape tab content -->
-            <div class="mview display-none" data-id="thematic">
-            </div>
+        <div class="corpus-documents-list-include h-100 w-100 position-relative pr-3">
+            <div class="simple-loader"><h5 class="mb-0 text">Loading...</h5></div>
         </div>
     </div>
 
 </div>
 
-
-<script>
-    // Tab switching functionality
-    $('body').on('click', '.documents-list-header .mtabs btn', function(){
-        const id = $(this).data('id');
-
-        $('.corpus-content .views .mview').each(function(){
-            if($(this).data('id') === id){
-                $(this).show();
-            } else{
-                $(this).hide();
-            }
-        });
-
-        $('.documents-list-header .mtabs btn').each(function(){
-            if($(this).data('id') === id){
-                $(this).addClass('selected-tab');
-            } else{
-                $(this).removeClass('selected-tab');
-            }
-        });
-    });
-
-
-</script>

--- a/uce.portal/resources/templates/css/corpus-inspector.css
+++ b/uce.portal/resources/templates/css/corpus-inspector.css
@@ -19,10 +19,6 @@
     border-bottom: 1px lightgray solid;
     height: 90px;
     background-color: rgba(245, 245, 247, 1);
-    padding: 0 16px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
 }
 
 .corpus-inspector .cheader a{
@@ -87,68 +83,5 @@
     position: sticky;
     width: 100%;
     border-bottom: lightgray 1px solid;
-    padding: 16px 16px 0 16px;
-    background-color: rgba(245, 245, 247, 1);
-    height: 90px;
-    display: flex;
-    flex-direction: column;
-}
-
-/* Tab styles */
-.documents-list-header .mtabs {
-    height: 40px;
-    display: flex;
-    align-items: flex-end;
-    justify-content: flex-start;
-    margin-top: auto;
-    padding-left: 0;
-    padding-bottom: 1px;
-
-}
-
-.documents-list-header .mtabs btn {
-    padding: 8px 20px;
-    height: 38px;
-    display: flex;
-    background-color: rgba(235, 235, 237, 1);
-    align-items: center;
-    justify-content: center;
-    border: 1px solid lightgray;
-    border-bottom: none;
-    cursor: pointer;
-    border-radius: 4px 4px 0 0;
-    font-weight: normal;
-    transition: all 0.2s ease;
-    position: relative;
-    bottom: -1px;
-}
-
-.documents-list-header .mtabs btn:hover {
-    background-color: white;
-}
-
-.documents-list-header .mtabs .selected-tab {
-    background-color: white;
-    height: 40px;
-    position: relative;
-    z-index: 1;
-    border-bottom: 1px solid white;
-    margin-bottom: -1px;
-    font-weight: bold;
-    bottom: -1px;
-}
-
-.corpus-content .views .mview {
-    display: block;
-    background-color: white;
-    border-left: 1px solid lightgray;
-    border-right: 1px solid lightgray;
-    border-bottom: 1px solid lightgray;
-    min-height: 300px;
-    max-height: calc(100vh - 90px);
-    overflow-y: auto;
-}
-
-.corpus-content .views .display-none {
-    display: none;
+    padding:16px;
 }

--- a/uce.portal/resources/templates/css/wiki.css
+++ b/uce.portal/resources/templates/css/wiki.css
@@ -642,3 +642,13 @@
     height:500px;
     width:100%
 }
+
+#topic-similar-topics-container {
+    height:500px;
+    width:100%
+}
+
+#topic-document-distribution-container {
+    height:500px;
+    width:100%
+}

--- a/uce.portal/resources/templates/js/graphViz.js
+++ b/uce.portal/resources/templates/js/graphViz.js
@@ -66,6 +66,13 @@ var GraphVizHandler = (function () {
         const cloudContainer = document.createElement('div');
         cloudContainer.className = 'word-cloud-container';
 
+        if (title) {
+            const titleElement = document.createElement('h5');
+            titleElement.className = 'word-cloud-title text-center';
+            titleElement.textContent = title;
+            target.insertBefore(titleElement, target.firstChild);
+        }
+
         const maxWeight = Math.max(...wordData.map(item => item.weight));
         const minWeight = Math.min(...wordData.map(item => item.weight));
         const weightRange = maxWeight - minWeight;
@@ -124,7 +131,7 @@ function getColorForWeight(weight) {
     const r = Math.floor(255 * (1 - weight));
     const g = Math.floor(200 * weight);
     const b = 0;
-    return "rgb(" + r + ", " + g + ", " + b + ")";
+    return "rgba(" + r + ", " + g + ", " + b + ", 0.5)";
 }
 
 window.graphVizHandler = getNewGraphVizHandler();

--- a/uce.portal/resources/templates/js/graphViz.js
+++ b/uce.portal/resources/templates/js/graphViz.js
@@ -85,6 +85,7 @@ var GraphVizHandler = (function () {
             const normalizedWeight = weightRange === 0 ? 1 : (item.weight - minWeight) / weightRange;
             const fontSize = 12 + (normalizedWeight * 24);
             word.style.fontSize = fontSize + "px";
+            word.style.cursor = 'default';
             word.style.color = getColorForWeight(normalizedWeight);
 
             word.addEventListener('mouseover', () => {

--- a/uce.portal/resources/templates/wiki/pages/corpusPage.ftl
+++ b/uce.portal/resources/templates/wiki/pages/corpusPage.ftl
@@ -70,14 +70,8 @@
         </div>
     </div>
 
-    <div class="text-center mb-3">
-        <h6 class="mb-3">${languageResource.get("corpusWords")}</h6>
-        <!-- Topic Word Cloud -->
-        <div class="col-md-6 mx-auto">
-            <div id="topicWordCloud"></div>
-        </div>
-    </div>
 
+    <div id="corpus-topic-word-cloud-container" class="col-md-8 mx-auto"></div>
     <div id="corpus-topic-distribution-container"></div>
 
 
@@ -125,13 +119,18 @@
             "labelName": "Topic Distribution"
         };
 
-        window.graphVizHandler.createWordCloud(document.getElementById('topicWordCloud'), 'Word Cloud', wordData);
+        if (wordData.length > 0) {
 
-        window.graphVizHandler.createBasicChart(document.getElementById('corpus-topic-distribution-container'),
-            'Topic Distribution in Corpus',
-            topicDistData,
-            'pie'
-        );
+            window.graphVizHandler.createWordCloud(document.getElementById('corpus-topic-word-cloud-container'), "${languageResource.get("corpusWords")}", wordData);
+        }
+
+        if (topicDistData.labels.length > 0 && topicDistData.data.length > 0) {
+            window.graphVizHandler.createBasicChart(document.getElementById('corpus-topic-distribution-container'),
+                'Topic Distribution in Corpus',
+                topicDistData,
+                'pie'
+            );
+        }
     })
 </script>
 

--- a/uce.portal/resources/templates/wiki/pages/documentAnnotationPage.ftl
+++ b/uce.portal/resources/templates/wiki/pages/documentAnnotationPage.ftl
@@ -13,12 +13,7 @@
 
     <hr class="mt-2 mb-4"/>
 
-    <div class="mt-3 mb-4">
-        <h6 class="text-dark text-center w-100 mb-2">
-            ${languageResource.get('documentWords')}
-        </h6>
-        <div id="topic-word-cloud" class="col-md-8 mx-auto"></div>
-    </div>
+    <div id="document-topic-word-cloud-container" class="col-md-8 mx-auto"></div>
     <div id="document-topic-distribution-container"></div>
     <div id="document-similar-documents-container"></div>
 
@@ -104,24 +99,37 @@
             "labelName": "Shared Words"
         };
 
-        window.graphVizHandler.createBasicChart(
-            document.getElementById('document-topic-distribution-container'),
-            'Topic Distribution',
-            topicsData,
-            'pie'
-        );
+        if (topicsData.data.length > 0) {
+            window.graphVizHandler.createBasicChart(
+                document.getElementById('document-topic-distribution-container'),
+                'Topic Distribution',
+                topicsData,
+                'pie'
+            );
+        } else {
+            document.getElementById('document-topic-distribution-container').style.display = 'none';
+        }
 
-        window.graphVizHandler.createWordCloud(
-            document.getElementById('topic-word-cloud'),
-            'Top 20 Topic Words',
-            wordData
-        );
+        if (wordData.length > 0) {
+            window.graphVizHandler.createWordCloud(
+                document.getElementById('document-topic-word-cloud-container'),
+                "${languageResource.get("documentWords")}",
+                wordData
+            );
+        } else {
+            document.getElementById('document-topic-word-cloud-container').style.display = 'none';
+        }
 
-        window.graphVizHandler.createBasicChart(document.getElementById('document-similar-documents-container'),
-            'Similar documents based on shared words',
-            similarDocumentsData,
-            'polarArea',
-        );
+        if (similarDocumentsData.data.length > 0) {
+            window.graphVizHandler.createBasicChart(
+                document.getElementById('document-similar-documents-container'),
+                'Similar documents based on shared words',
+                similarDocumentsData,
+                'polarArea'
+            );
+        } else {
+            document.getElementById('document-similar-documents-container').style.display = 'none';
+        }
 
     })
 </script>

--- a/uce.portal/resources/templates/wiki/pages/topicPage.ftl
+++ b/uce.portal/resources/templates/wiki/pages/topicPage.ftl
@@ -12,20 +12,9 @@
 
     <hr class="mt-2 mb-4"/>
 
-    <!-- Topic Summary -->
-    <div class="text-center mb-3">
-        <h4 class="mb-3">Topic: ${vm.getCoveredText()}</h4>
-        <!-- Topic Word Cloud -->
-        <div class="col-md-6 mx-auto">
-            <div id="topicWordCloud"></div>
-        </div>
-    </div>
-    <hr class="mt-2 mb-4"/>
-
-    <div class="row m-0 p-0" style="height: 500px; width:100%">
-        <div id="document-distribution-container" class="col-6 m-0 p-2"></div>
-        <div id="similar-topics-container" class="col-6 m-0 p-2"></div>
-    </div>
+    <div id="topic-word-cloud-container" class="col-md-8 mx-auto"></div>
+    <div id="topic-document-distribution-container"></div>
+    <div id="topic-similar-topics-container"></div>
 
     <!-- the document this is from -->
     <div class="mt-4 mb-3 w-100 p-0 m-0 justify-content-center flexed align-items-start">
@@ -79,20 +68,31 @@
         "labelName": "Shared Words"
     };
 
-    window.graphVizHandler.createBasicChart(document.getElementById('document-distribution-container'),
-        'Document Distribution of the topic',
-        documentDistData,
-        'bar',
-    );
+    if (documentDistData.data.length > 0) {
+        window.graphVizHandler.createBasicChart(document.getElementById('topic-document-distribution-container'),
+            'Document Distribution of the topic',
+            documentDistData,
+            'bar',
+        );
+    } else {
+        document.getElementById('topic-document-distribution-container').style.display = 'none';
+    }
 
-    window.graphVizHandler.createBasicChart(document.getElementById('similar-topics-container'),
-        'Similar topic based on shared words',
-        similarTopicsData,
-        'polarArea',
-    );
+    if (similarTopicsData.data.length > 0) {
+        window.graphVizHandler.createBasicChart(document.getElementById('topic-similar-topics-container'),
+            'Similar topic based on shared words',
+            similarTopicsData,
+            'polarArea',
+        );
+    } else {
+        document.getElementById('topic-similar-topics-container').style.display = 'none';
+    }
 
-    window.graphVizHandler.createWordCloud(document.getElementById('topicWordCloud'), 'Word Cloud', wordData);
-
+    if (wordData.length > 0) {
+        window.graphVizHandler.createWordCloud(document.getElementById('topic-word-cloud-container'), "${languageResource.get("topicWords")}", wordData);
+    } else {
+        document.getElementById('topic-word-cloud-container').style.display = 'none';
+    }
 
 
 

--- a/uce.portal/uce.web/src/main/resources/languageTranslations.json
+++ b/uce.portal/uce.web/src/main/resources/languageTranslations.json
@@ -368,11 +368,19 @@
     "en-EN": "Key Topics"
   },
   "corpusWords": {
-    "de-DE": "Top 20 Wörter aus dem Korpus",
-    "en-EN": "Top 20 words from Corpus"
+    "de-DE": "Top Wörter aus dem Korpus",
+    "en-EN": "Top words from Corpus"
   },
   "documentWords": {
-    "de-DE": "Top 20 Wörter aus dem Dokument",
-    "en-EN": "Top 20 words from document"
+    "de-DE": "Top Wörter aus dem Dokument",
+    "en-EN": "Top words from document"
+  },
+  "topicWords": {
+    "de-DE": "Top Wörter aus dem Thema",
+    "en-EN": "Top words from Topic"
+  },
+  "topicDistribution": {
+    "de-DE": "Thema Verteilung",
+    "en-EN": "Topic Distribution"
   }
 }


### PR DESCRIPTION
This PR fixes visualizations for the topic related plots. When plot data is not available then the plot containers are now hidden. It also tone down the gradient coloring for topics, adds more transparency. Additionally, it also removes the multi-tab view from corpus inspector.