### PR TITLE
Add minimap scrollbar to documentReader

### DIFF
--- a/uce.portal/resources/templates/css/document-reader.css
+++ b/uce.portal/resources/templates/css/document-reader.css
@@ -476,3 +476,97 @@ body {
     font-weight: 700;
     opacity: 1.2;
 }
+
+/* Scrollbar Minimap Styles */
+.scrollbar-minimap {
+    position: fixed;
+    right: 510px; /* Position to the left of the sidebar */
+    top: 150px;
+    width: 20px;
+    height: 80vh;
+    background-color: #f5f5f5;
+    border-left: 1px solid #ddd;
+    z-index: 50;
+    cursor: pointer;
+}
+
+/* Adjust minimap position when sidebar is collapsed */
+.side-bar[style*="width: 20px"] ~ .reader-container .scrollbar-minimap {
+    right: 30px;
+}
+
+.minimap-markers {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.minimap-marker {
+    position: absolute;
+    left: 0;
+    width: 100%;
+    height: 3px;
+    transition: all 0.2s ease;
+    opacity: 0.7;
+}
+
+/*.minimap-marker:hover {*/
+/*    height: 5px;*/
+/*    opacity: 1;*/
+/*    box-shadow: 0 0 3px rgba(0,0,0,0.3);*/
+/*}*/
+
+.minimap-marker.topic-marker {
+    opacity: 0.9;
+    z-index: 2;
+}
+
+.minimap-marker.all-topics-marker {
+    opacity: 0.6;
+    z-index: 1;
+}
+
+.minimap-preview {
+    position: absolute;
+    right: 40px;
+    width: 300px;
+    max-height: 150px;
+    background-color: #ffffff;
+    border: 2px solid #b8b8b8;
+    border-radius: 4px;
+    padding: 10px;
+    font-size: 12px;
+    display: none;
+    overflow: hidden;
+    z-index: 51;
+    --b: 2em; /* base */
+    --h: 1em; /* height */
+
+    --p: 50%; /* triangle position (0%:top 100%:bottom) */
+    --r: 1.2em; /* the radius */
+    --c: #ffffff;
+
+    padding: 1em;
+    border-radius: var(--r)/var(--r) min(var(--r),var(--p) - var(--b)/2) min(var(--r),100% - var(--p) - var(--b)/2) var(--r);
+    clip-path: polygon(100% 100%,0 100%,0 0,100% 0,
+    100% max(0%  ,var(--p) - var(--b)/2),
+    calc(100% + var(--h)) var(--p),
+    100% min(100%,var(--p) + var(--b)/2));
+    background: var(--c);
+    border-image: conic-gradient(var(--c) 0 0) fill 0/
+    calc(var(--p) - var(--b)/2) 0 calc(100% - var(--p) - var(--b)/2) var(--r)/
+    0 var(--h) 0 0;
+}
+
+
+.preview-content {
+    font-family: Courier, monospace;
+    font-size: 12px;
+    line-height: 1.4;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 130px;
+    overflow: hidden;
+}

--- a/uce.portal/resources/templates/js/documentReader.js
+++ b/uce.portal/resources/templates/js/documentReader.js
@@ -144,6 +144,14 @@ $(document).ready(function () {
     // Load document topics
     loadDocumentTopics();
 
+    const hasTopics = $('.colorable-topic').length > 0;
+    if (hasTopics) {
+        $('.scrollbar-minimap').show();
+        initScrollbarMinimap();
+    } else {
+        $('.scrollbar-minimap').hide();
+    }
+
     let possibleSearchTokens = $('.reader-container').data('searchtokens');
     if (possibleSearchTokens === undefined || possibleSearchTokens === '') return;
     searchTokens = possibleSearchTokens.split('[TOKEN]');
@@ -203,9 +211,13 @@ function loadDocumentTopics() {
         $('.document-topics-list').html(html);
         attachTopicClickHandlers();
 
-
+        if (typeof updateMinimapMarkers === 'function') {
+            setTimeout(updateMinimapMarkers, 500);
+        }
     } else {
         $('.document-topics-list').html('<p>No topics found in this document.</p>');
+        // Hide the minimap since there are no topics
+        $('.scrollbar-minimap').hide();
     }
 }
 
@@ -289,6 +301,7 @@ async function lazyLoadPages() {
                     if ($activeTopic.length > 0) {
                         colorUnifiedTopics($activeTopic.data('topic'));
                     }
+                    updateMinimapMarkers();
                 },
                 error: function (xhr, status, error) {
                     console.error(xhr.responseText);
@@ -378,6 +391,7 @@ function colorUnifiedTopics(selectedTopic) {
             });
         }
     });
+    updateTopicMarkersOnMinimap();
 }
 
 function clearTopicColoring() {
@@ -386,6 +400,9 @@ function clearTopicColoring() {
         'border-radius': '',
         'padding': ''
     });
+
+    $('.minimap-marker.topic-marker').remove();
+    $('.minimap-marker.all-topics-marker').show();
 }
 
 
@@ -454,4 +471,305 @@ function updateTopicNavButtonStates() {
     } else {
         $('.next-topic-button').removeClass('disabled');
     }
+}
+
+function initScrollbarMinimap() {
+    setTimeout(updateMinimapMarkers, 500);
+
+    $(window).on('scroll', function() {
+        updateMinimapScroll();
+    });
+
+    $(window).on('resize', function() {
+        updateMinimapMarkers();
+        updateMinimapScroll();
+    });
+
+    $('.scrollbar-minimap').on('click', function(e) {
+        const clickPosition = (e.pageY - $(this).offset().top) / $(this).height();
+        const dimensions = getMinimapDimensions();
+        const documentPosition = minimapToDocumentPosition(clickPosition * dimensions.minimapHeight, dimensions);
+
+        const scrollTo = documentPosition - (dimensions.windowHeight / 2);
+        $('html, body').animate({
+            scrollTop: Math.max(0, scrollTo)
+        }, 300);
+    });
+
+    $(document).on('mouseenter', '.minimap-marker', function(e) {
+        const $marker = $(this);
+        const $preview = $('.minimap-preview');
+        const $previewContent = $('.preview-content');
+        const dimensions = getMinimapDimensions();
+
+        let previewText = '';
+        let previewTitle = '';
+
+        const topicValue = $marker.data('topic');
+        if (topicValue && topicValue !== 'multiple') {
+            previewTitle = '<strong>Topic: ' + topicValue + '</strong>';
+
+            const markerTop = parseFloat($marker.css('top'));
+            const approximateDocumentPosition = minimapToDocumentPosition(markerTop, dimensions);
+
+            const $topicElements = $('.colorable-topic').filter(function() {
+                return $(this).data('topic-value') === topicValue;
+            });
+
+            let closestElement = null;
+            let minDistance = Number.MAX_VALUE;
+
+            $topicElements.each(function() {
+                const $element = $(this);
+                const elementOffset = $element.offset();
+
+                if (elementOffset) {
+                    const distance = Math.abs(elementOffset.top - approximateDocumentPosition);
+                    if (distance < minDistance) {
+                        minDistance = distance;
+                        closestElement = $element;
+                    }
+                }
+            });
+
+            if (closestElement) {
+                const $paragraph = closestElement.closest('p');
+                if ($paragraph.length) {
+                    let contextText = $paragraph.text().trim();
+                    if (contextText.length > 200) {
+                        contextText = contextText.substring(0, 200) + '...';
+                    }
+                    previewText = contextText;
+                } else {
+                    previewText = closestElement.text().trim();
+                }
+
+                const coveredText = closestElement.data('wcovered');
+                if (coveredText) {
+                    previewText =  coveredText;
+                }
+            }
+            if (previewTitle) {
+                $previewContent.html(previewTitle + '<br><br>' + previewText);
+            } else {
+                $previewContent.text(previewText);
+            }
+
+            const previewHeight = $preview.outerHeight();
+            let previewTop = markerTop - (previewHeight / 2);
+            if (previewTop < 0) previewTop = 0;
+            if (previewTop + previewHeight > dimensions.minimapHeight) {
+                previewTop = dimensions.minimapHeight - previewHeight;
+            }
+
+            $preview.css('top', previewTop + 'px').show();
+        } else {
+            // Get the text content from the corresponding document section
+            // const elementId = $marker.data('element-id');
+            // const $element = $('#' + elementId);
+            //
+            // if ($element.length) {
+            //     // Get a snippet of text from the element
+            //     previewText = $element.text().trim();
+            //     // Limit preview text length
+            //     if (previewText.length > 200) {
+            //         previewText = previewText.substring(0, 200) + '...';
+            //     }
+            // }
+        }
+    });
+
+    $(document).on('mouseleave', '.minimap-marker', function() {
+        $('.minimap-preview').hide();
+    });
+
+    $('.scrollbar-minimap').on('mouseleave', function() {
+        $('.minimap-preview').hide();
+    });
+}
+
+function updateMinimapMarkers() {
+    const $minimap = $('.minimap-markers');
+    const dimensions = getMinimapDimensions();
+    
+    $minimap.empty();
+
+    $('.document-content .page').each(function(index) {
+        const $page = $(this);
+
+        if (!$page.attr('id')) {
+            $page.attr('id', 'page-' + (index + 1));
+        }
+
+        const pageId = $page.attr('id');
+        const pageTop = $page.offset().top;
+        const pageHeight = $page.outerHeight();
+
+        const markerTop = documentToMinimapPosition(pageTop, dimensions);
+        const markerHeight = documentToMinimapPosition(pageHeight, dimensions);
+
+        const $marker = createMinimapMarker({
+            top: markerTop,
+            height: markerHeight,
+            color: '#ccc',
+            elementId: pageId
+        });
+
+        $minimap.append($marker);
+    });
+
+    addAllTopicMarkersToMinimap();
+    updateTopicMarkersOnMinimap();
+}
+
+function addAllTopicMarkersToMinimap() {
+    const $minimap = $('.minimap-markers');
+    const dimensions = getMinimapDimensions();
+    const topicPositions = {};
+
+    $('.colorable-topic').each(function() {
+        const $topic = $(this);
+        const topicValue = $topic.data('topic-value');
+
+        if (topicValue && topicColorMap[topicValue]) {
+            const topicTop = $topic.offset().top;
+            const topicHeight = $topic.outerHeight();
+
+            const markerTop = Math.floor(documentToMinimapPosition(topicTop, dimensions));
+            const markerHeight = Math.max(2, documentToMinimapPosition(topicHeight, dimensions));
+
+            if (!topicPositions[markerTop]) {
+                topicPositions[markerTop] = {
+                    topics: {},
+                    height: markerHeight
+                };
+            }
+
+            topicPositions[markerTop].topics[topicValue] = topicColorMap[topicValue];
+            topicPositions[markerTop].height = Math.max(topicPositions[markerTop].height, markerHeight);
+        }
+    });
+
+    Object.keys(topicPositions).forEach(function(position) {
+        const pos = parseInt(position);
+        const topicData = topicPositions[pos];
+        const topicValues = Object.keys(topicData.topics);
+
+        if (topicValues.length > 0) {
+            const topicValue = topicValues[0];
+            const color = topicData.topics[topicValue];
+
+            const $marker = createMinimapMarker({
+                top: pos,
+                height: topicData.height,
+                color: color,
+                topic: topicValues.length === 1 ? topicValue : 'multiple',
+                className: 'all-topics-marker'
+            });
+
+            $minimap.append($marker);
+        }
+    });
+}
+
+function updateTopicMarkersOnMinimap() {
+    const $minimap = $('.minimap-markers');
+    const dimensions = getMinimapDimensions();
+
+    const $activeTopic = $('.topic-tag.active-topic');
+    if ($activeTopic.length === 0) return;
+
+    $('.minimap-marker.all-topics-marker').hide();
+
+    const activeTopic = $activeTopic.data('topic');
+    const topicColor = $activeTopic.css('background-color');
+
+    $('.colorable-topic').each(function() {
+        const $topic = $(this);
+        const topicValue = $topic.data('topic-value');
+
+        if (topicValue === activeTopic) {
+            const topicTop = $topic.offset().top;
+            const topicHeight = $topic.outerHeight();
+
+            const markerTop = documentToMinimapPosition(topicTop, dimensions);
+            const markerHeight = Math.max(3, documentToMinimapPosition(topicHeight, dimensions));
+
+            const $marker = createMinimapMarker({
+                top: markerTop,
+                height: markerHeight,
+                color: topicColor,
+                className: 'topic-marker'
+            });
+
+            $minimap.append($marker);
+        }
+    });
+}
+
+// Helper functions for minimap calculations
+function getMinimapDimensions() {
+    return {
+        documentHeight: $(document).height(),
+        windowHeight: $(window).height(),
+        minimapHeight: $('.scrollbar-minimap').height()
+    };
+}
+
+function documentToMinimapPosition(documentPos, dimensions) {
+    const { documentHeight, minimapHeight } = dimensions || getMinimapDimensions();
+    return (documentPos / documentHeight) * minimapHeight;
+}
+
+function minimapToDocumentPosition(minimapPos, dimensions) {
+    const { documentHeight, minimapHeight } = dimensions || getMinimapDimensions();
+    return (minimapPos / minimapHeight) * documentHeight;
+}
+
+function createMinimapMarker(options) {
+    const { top, height, color, elementId, topic, className } = options;
+    
+    const $marker = $('<div></div>')
+        .addClass('minimap-marker')
+        .addClass(className || '')
+        .css({
+            'top': top + 'px',
+            'height': Math.max(2, height) + 'px',
+            'background-color': color || '#ccc'
+        });
+    
+    if (elementId) $marker.attr('data-element-id', elementId);
+    if (topic) $marker.attr('data-topic', topic);
+    
+    return $marker;
+}
+
+function updateMinimapScroll() {
+    const windowHeight = $(window).height();
+    const documentHeight = $(document).height();
+    const scrollTop = $(window).scrollTop();
+    const minimapHeight = $('.scrollbar-minimap').height();
+
+    const visibleStart = scrollTop / documentHeight;
+    const visibleHeight = windowHeight / documentHeight;
+
+    let $visibleArea = $('.minimap-visible-area');
+    if ($visibleArea.length === 0) {
+        $visibleArea = $('<div class="minimap-visible-area"></div>')
+            .css({
+                'position': 'absolute',
+                'left': '0',
+                'width': '100%',
+                'background-color': 'rgba(0, 0, 0, 0.1)',
+                'border-top': '1px solid rgba(0, 0, 0, 0.2)',
+                'border-bottom': '1px solid rgba(0, 0, 0, 0.2)',
+                'z-index': 1
+            });
+        $('.scrollbar-minimap').append($visibleArea);
+    }
+
+    $visibleArea.css({
+        'top': (visibleStart * minimapHeight) + 'px',
+        'height': (visibleHeight * minimapHeight) + 'px'
+    });
 }

--- a/uce.portal/resources/templates/reader/documentReaderView.ftl
+++ b/uce.portal/resources/templates/reader/documentReaderView.ftl
@@ -150,6 +150,13 @@
                         <#assign documentAnnotations = document.getAllAnnotations(0, 10)>
                         <#include '*/reader/components/pagesList.ftl' />
                     </div>
+                    <!-- Scrollbar Minimap -->
+                    <div class="scrollbar-minimap">
+                        <div class="minimap-markers"></div>
+                        <div class="minimap-preview">
+                            <div class="preview-content"></div>
+                        </div>
+                    </div>
 
                 </div>
             </div>


### PR DESCRIPTION
This PR adds a minimap scrollbar to the documentReader. This is a colored minimap representing the distribution of topics over the whole document. While hovering over the colored stripes, a specific unified topic is shown. When a key topic is selected from the navigation bar, only the unified topic with respect to that topic is shown on the minimap.