### PR TITLE
Topic Similarity visualization

### DIFF
--- a/uce.portal/resources/templates/css/document-reader.css
+++ b/uce.portal/resources/templates/css/document-reader.css
@@ -673,6 +673,34 @@ body {
     outline: none;
 }
 
+.viz-panel .selector-container {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-family: sans-serif;
+    margin: 10px;
+}
+
+.viz-panel .selector-container label {
+    font-weight: 600;
+    min-width: 120px;
+    display: contents;
+}
+
+.viz-panel .selector-container #similarityTypeSelector {
+    padding: 6px 10px;
+    font-size: 14px;
+    border-radius: 5px;
+    border: 1px solid #ccc;
+    background-color: #f9f9f9;
+    transition: border-color 0.2s ease-in-out;
+}
+
+.viz-panel .selector-container #similarityTypeSelector:focus {
+    border-color: #007bff;
+    outline: none;
+}
+
 #vp-3, #vp-4, #vp-5, #vp-2, #vp-1 {
     display: flex;
     align-items: center;

--- a/uce.portal/resources/templates/js/documentReader.js
+++ b/uce.portal/resources/templates/js/documentReader.js
@@ -856,6 +856,8 @@ $(document).on('click', '.viz-nav-btn', function () {
 
     }
     if (target === '#viz-panel-4') {
+        $('.selector-container').hide();
+        setTimeout(() => renderTopicSimilarityMatrix('vp-4'), 500);
 
     }
     if (target === '#viz-panel-5') {
@@ -863,6 +865,102 @@ $(document).on('click', '.viz-nav-btn', function () {
 
     }
 });
+
+function computeTopicSimilarityMatrix(data, type = "cosine") {
+    const topicLabels = data.map(t => t.topicLabel);
+    const wordProbMaps = data.map(t => t.words);
+    const allWords = new Set(data.flatMap(t => Object.keys(t.words)));
+
+    const matrix = [];
+
+    for (let i = 0; i < wordProbMaps.length; i++) {
+        for (let j = 0; j < wordProbMaps.length; j++) {
+            let score = 0;
+
+            if (type === "cosine") {
+                let dot = 0, normI = 0, normJ = 0;
+                for (const word of allWords) {
+                    const p1 = wordProbMaps[i][word] || 0;
+                    const p2 = wordProbMaps[j][word] || 0;
+                    dot += p1 * p2;
+                    normI += p1 * p1;
+                    normJ += p2 * p2;
+                }
+                score = (normI === 0 || normJ === 0) ? 0 : dot / (Math.sqrt(normI) * Math.sqrt(normJ));
+
+            } else if (type === "count") {
+                const wordsI = new Set(Object.keys(wordProbMaps[i]));
+                const wordsJ = new Set(Object.keys(wordProbMaps[j]));
+                const shared = [...wordsI].filter(w => wordsJ.has(w));
+                score = shared.length;
+            }
+
+            matrix.push([i, j, score]);
+        }
+    }
+
+    return {
+        labels: topicLabels,
+        matrix: matrix
+    };
+}
+
+
+
+function renderTopicSimilarityMatrix(containerId) {
+    const container = document.getElementById(containerId);
+    if (!container || container.classList.contains('rendered')){
+        $('.selector-container').show();
+        return;
+    }
+    const rawValue = document.getElementById('vp-1')?.getAttribute('data-document-id');
+    const docId = rawValue ? parseInt(rawValue, 10) : null;
+    if (!docId) {
+        console.error("Missing or invalid documentId for Chord Diagram");
+        return;
+    }
+
+
+    $.get('/api/document/page/topicWords', { documentId: docId })
+        .then(data => {
+            if (!data || !Array.isArray(data) || data.length === 0) {
+                const container = document.getElementById(containerId);
+                if (container) {
+                    container.innerHTML = '<div style="color:#888;">No data available</div>';
+                }
+                return;
+            }
+            $('.selector-container').show();
+            const similarityTypeSelector = document.getElementById('similarityTypeSelector');
+
+            function updateChart() {
+                const type = similarityTypeSelector.value;
+                const { labels, matrix } = computeTopicSimilarityMatrix(data, type);
+
+                const tooltipFormatter = function (params) {
+                    const xLabel = labels[params.data[0]];
+                    const yLabel = labels[params.data[1]];
+                    const value = type === "count" ? params.data[2] : params.data[2].toFixed(3);
+                   return xLabel + " & " + yLabel + "<br>" + (type.charAt(0).toUpperCase() + type.slice(1)) + ": " + value;
+                };
+
+                window.graphVizHandler.createHeatMap(
+                    containerId,
+                    "Topic Similarity (" + type + ")",
+                    matrix,
+                    labels,
+                    "Similarity (" + type + ")",
+                    tooltipFormatter
+                );
+
+            }
+
+            similarityTypeSelector.addEventListener('change', updateChart);
+            updateChart();
+            container.classList.add('rendered');
+        });
+}
+
 
 function renderTopicEntityChordDiagram(containerId) {
     const container = document.getElementById(containerId);
@@ -893,8 +991,8 @@ function renderTopicEntityChordDiagram(containerId) {
 
             // Step 1: build nodes
             data.forEach(item => {
-                const topic = item.topiclabel;
-                const entityType = item.entity_type;
+                const topic = item.topicLabel;
+                const entityType = item.entityType;
 
                 if (topic && !nodeMap.has(topic)) {
                     nodeMap.set(topic, nodeIndex++);
@@ -951,13 +1049,13 @@ function renderTopicEntityChordDiagram(containerId) {
                 const isEntity = node.category === 1;
 
                 const filtered = data.filter(item => {
-                    return isEntity ? item.entity_type === clickedNodeName : item.topiclabel === clickedNodeName;
+                    return isEntity ? item.entityType === clickedNodeName : item.topicLabel === clickedNodeName;
                 });
                 const aggMap = new Map();
 
                 filtered.forEach(item => {
                     // The other side of the relation
-                    const key = isEntity ? item.topiclabel : item.entity_type;
+                    const key = isEntity ? item.topicLabel : item.entityType;
                     if (key) {
                         aggMap.set(key, (aggMap.get(key) || 0) + 1);
                     }

--- a/uce.portal/resources/templates/js/documentReader.js
+++ b/uce.portal/resources/templates/js/documentReader.js
@@ -926,7 +926,7 @@ function renderTopicSimilarityMatrix(containerId) {
             if (!data || !Array.isArray(data) || data.length === 0) {
                 const container = document.getElementById(containerId);
                 if (container) {
-                    container.innerHTML = '<div style="color:#888;">No data available</div>';
+                    container.innerHTML = '<div style="color:#888;">' + container.getAttribute('data-message') + '</div>';
                 }
                 return;
             }

--- a/uce.portal/resources/templates/js/graphViz.js
+++ b/uce.portal/resources/templates/js/graphViz.js
@@ -453,6 +453,84 @@ var GraphVizHandler = (function () {
         return echart;
     };
 
+    GraphVizHandler.prototype.createHeatMap = async function (
+        target,
+        title,
+        matrix,
+        labels,
+        series_name= null,
+        tooltipFormatter = null,
+        onClick = null
+    ) {
+        const chartId = generateUUID();
+        const option = {
+            title: {
+                text: title,
+                left: 'center'
+            },
+            tooltip: {
+                position: 'top',
+                formatter: tooltipFormatter,
+            },
+            grid: {
+                left: '15%',
+                bottom: '15%',
+                containLabel: true
+            },
+            xAxis: {
+                type: 'category',
+                data: labels,
+                splitArea: {
+                    show: true
+                },
+                axisLabel: {
+                    rotate: 45
+                }
+            },
+            yAxis: {
+                type: 'category',
+                data: labels,
+                splitArea: {
+                    show: true
+                }
+            },
+            visualMap: {
+                min: 0,
+                max: Math.max(...matrix.map(d => d[2])),
+                calculable: true,
+                orient: 'horizontal',
+                left: 'center',
+                bottom: '5%'
+            },
+            series: [{
+                name: series_name || 'Heatmap',
+                type: 'heatmap',
+                data: matrix,
+                roam: true,
+                label: {
+                    show: false
+                },
+                emphasis: {
+                    itemStyle: {
+                        shadowBlur: 10,
+                        shadowColor: 'rgba(0, 0, 0, 0.5)'
+                    }
+                }
+            }]
+        };
+
+        const echart = new ECharts(target, option);
+        this.activeCharts[chartId] = echart;
+
+        echart.getInstance().on('click', function (params) {
+            if (onClick && typeof onClick === 'function') {
+                onClick(params);
+            }
+        });
+
+        return echart;
+    };
+
 
     return GraphVizHandler;
 }());

--- a/uce.portal/resources/templates/reader/documentReaderView.ftl
+++ b/uce.portal/resources/templates/reader/documentReaderView.ftl
@@ -273,7 +273,7 @@
                                                 <option value="count" title="Shared Count: Simply counts overlapping words between topics">Shared Count</option>
                                             </select>
                                         </div>
-                                        <div id="vp-4"></div>
+                                        <div id="vp-4" data-message="${languageResource.get('noDataAvailable')}"></div>
                                     </div>
 
                                 </div>

--- a/uce.portal/resources/templates/reader/documentReaderView.ftl
+++ b/uce.portal/resources/templates/reader/documentReaderView.ftl
@@ -269,8 +269,8 @@
                                         <div class="selector-container">
                                             <label for="similarityTypeSelector">Similarity Type:</label>
                                             <select id="similarityTypeSelector">
-                                                <option value="cosine" title="Cosine: Measures angular similarity of topic-word vectors">Cosine</option>
-                                                <option value="count" title="Shared Count: Simply counts overlapping words between topics">Shared Count</option>
+                                                <option value="cosine" title="${languageResource.get('cosine')}">Cosine</option>
+                                                <option value="count" title="${languageResource.get('overlap')}">Shared Count</option>
                                             </select>
                                         </div>
                                         <div id="vp-4" data-message="${languageResource.get('noDataAvailable')}"></div>

--- a/uce.portal/resources/templates/reader/documentReaderView.ftl
+++ b/uce.portal/resources/templates/reader/documentReaderView.ftl
@@ -265,7 +265,17 @@
                                     <div id="vp-3"></div>
                                 </div>
                                 <div class="viz-panel" id="viz-panel-4">
-                                    <div id="vp-4" data-document-text="${document.getFullText()}"></div>
+                                    <div id="vp-4-wrapper">
+                                        <div class="selector-container">
+                                            <label for="similarityTypeSelector">Similarity Type:</label>
+                                            <select id="similarityTypeSelector">
+                                                <option value="cosine" title="Cosine: Measures angular similarity of topic-word vectors">Cosine</option>
+                                                <option value="count" title="Shared Count: Simply counts overlapping words between topics">Shared Count</option>
+                                            </select>
+                                        </div>
+                                        <div id="vp-4"></div>
+                                    </div>
+
                                 </div>
                                 <div class="viz-panel" id="viz-panel-5">
                                     <div id="vp-5" ></div>

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/PostgresqlDataInterface_Impl.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/PostgresqlDataInterface_Impl.java
@@ -1846,6 +1846,22 @@ public class PostgresqlDataInterface_Impl implements DataInterface {
         });
     }
 
+    public List<Object[]> getTopicWordsByDocumentId(long documentId) throws DatabaseOperationException {
+        return executeOperationSafely((session) -> {
+            String sql = "SELECT topiclabel, word, AVG(probability) AS avg_probability " +
+                    "FROM documenttopicwords " +
+                    "WHERE document_id = :documentId " +
+                    "GROUP BY topiclabel, word " +
+                    "ORDER BY avg_probability DESC";
+
+            var query = session.createNativeQuery(sql);
+            query.setParameter("documentId", documentId);
+
+            List<Object[]> results = query.getResultList();
+
+            return results;
+        });
+    }
 
 
 

--- a/uce.portal/uce.web/src/main/java/org/texttechnologylab/App.java
+++ b/uce.portal/uce.web/src/main/java/org/texttechnologylab/App.java
@@ -395,6 +395,7 @@ public class App {
                 get("/page/taxon", documentApi.getTaxonCountByPage);
                 get("/page/topics", documentApi.getDocumentTopicDistributionByPage);
                 get("/page/topicEntityRelation", documentApi.getSentenceTopicsWithEntities);
+                get("/page/topicWords", documentApi.getTopicWordsByDocument);
             });
 
             path("/rag", () -> {

--- a/uce.portal/uce.web/src/main/resources/languageTranslations.json
+++ b/uce.portal/uce.web/src/main/resources/languageTranslations.json
@@ -442,5 +442,9 @@
   "topicDistribution": {
     "de-DE": "Thema Verteilung",
     "en-EN": "Topic Distribution"
+  },
+  "noDataAvailable": {
+    "de-DE": "Keine Daten verfügbar.",
+    "en-EN": "No data available."
   }
 }

--- a/uce.portal/uce.web/src/main/resources/languageTranslations.json
+++ b/uce.portal/uce.web/src/main/resources/languageTranslations.json
@@ -446,5 +446,13 @@
   "noDataAvailable": {
     "de-DE": "Keine Daten verfügbar.",
     "en-EN": "No data available."
+  },
+  "cosine": {
+    "de-DE": "Misst die Winkelsimilarität von Themen-Wort-Vektoren",
+    "en-EN": " Zählt einfach die überlappenden Wörter zwischen Themen"
+  },
+  "overlap": {
+    "de-DE": "Zählt einfach die überlappenden Wörter zwischen Themen",
+    "en-EN": "Counts simply the overlapping words between topics"
   }
 }


### PR DESCRIPTION
This PR adds topic similarity visualization to the Visualization tab. It create route to access topic words from the database. Topic words are used to calculate similarity between topics based on the count of similar word between the topics or using cosine similarity by considering topic word probability as topic vector.