### PR TITLE
Add Named Entities to Semantic Density Visualization

### DIFF
--- a/uce.portal/resources/templates/js/documentReader.js
+++ b/uce.portal/resources/templates/js/documentReader.js
@@ -1387,10 +1387,11 @@ function renderTemporalExplorer(containerId) {
 
     const taxonReq = $.get('/api/document/page/taxon', { documentId: docId });
     const topicReq = $.get('/api/document/page/topics', { documentId: docId });
+    const entityReq = $.get('/api/document/page/namedEntities', { documentId: docId });
 
-    Promise.all([taxonReq, topicReq]).then(([taxon, topics]) => {
+    Promise.all([taxonReq, topicReq, entityReq]).then(([taxon, topics, entities]) => {
         $('.visualization-spinner').hide()
-        if ((!taxon || taxon.length === 0) && (!topics || topics.length === 0)) {
+        if ((!taxon || taxon.length === 0) && (!topics || topics.length === 0) && (!entities || entities.length === 0)) {
             const container = document.getElementById(containerId);
             if (container) {
                 container.innerHTML = '<div style="color:#888;">' + document.getElementById('viz-content').getAttribute('data-message') + '</div>';
@@ -1402,8 +1403,8 @@ function renderTemporalExplorer(containerId) {
             {
                 key: 'taxon',
                 data: taxon,
-                pageField: 'page_id',
-                valueField: 'taxon_value',
+                pageField: 'pageId',
+                valueField: 'taxonValue',
                 label: 'Taxon',
                 color: '#91CC75',
                 transformValue: v => v.split('|')[0]
@@ -1411,10 +1412,20 @@ function renderTemporalExplorer(containerId) {
             {
                 key: 'topics',
                 data: topics,
-                pageField: 'page_id',
-                valueField: 'topiclabel',
+                pageField: 'pageId',
+                valueField: 'topicLabel',
                 label: 'Topics',
                 color: '#75ccc5'
+            }
+            ,
+            {
+                key: 'ne',
+                data: entities,
+                pageField: 'pageId',
+                valueField: 'entityType',
+                label: 'Named Entities',
+                color: '#5470C6',
+                transformValue: v => v.split('|')[0]
             }
         ];
 

--- a/uce.portal/resources/templates/js/documentReader.js
+++ b/uce.portal/resources/templates/js/documentReader.js
@@ -905,6 +905,7 @@ function renderSentenceTopicNetwork(containerId) {
                         if (container) {
                             container.innerHTML = '<div style="color:#888;">' + document.getElementById('viz-content').getAttribute('data-message') + '</div>';
                         }
+                        container.classList.add('rendered');
                         return;
                     }
                     const sentenceEmbeddingMap = new Map();
@@ -1092,6 +1093,8 @@ function renderTopicSimilarityMatrix(containerId) {
                 if (container) {
                     container.innerHTML = '<div style="color:#888;">' + document.getElementById('viz-content').getAttribute('data-message') + '</div>';
                 }
+                container.classList.remove('rendered');
+                $('.selector-container').hide();
                 return;
             }
             $('.selector-container').show();
@@ -1142,6 +1145,7 @@ function renderTopicEntityChordDiagram(containerId) {
                 if (container) {
                     container.innerHTML = '<div style="color:#888;">' + document.getElementById('viz-content').getAttribute('data-message') + '</div>';
                 }
+                container.classList.add('rendered');
                 return;
             }
             const nodeMap = new Map();
@@ -1285,10 +1289,21 @@ function renderSentenceTopicSankey(containerId) {
 
     $('.visualization-spinner').show()
 
+    const $colorableTopics = $('.colorable-topic');
+    if ($colorableTopics.length === 0) {
+        $('.visualization-spinner').hide()
+        const container = document.getElementById(containerId);
+        if (container) {
+            container.innerHTML = '<div style="color:#888;">' + document.getElementById('viz-content').getAttribute('data-message') + '</div>';
+        }
+        container.classList.add('rendered');
+        return;
+    }
+
     let sentenceTopicData = [];
     const topicFrequency = {};
 
-    $('.colorable-topic').each(function () {
+    $colorableTopics.each(function () {
         const topicValue = $(this).data('topic-value');
         const utId = parseInt(this.id.replace('utopic-UT-', ''));
 
@@ -1375,6 +1390,14 @@ function renderTemporalExplorer(containerId) {
 
     Promise.all([taxonReq, topicReq]).then(([taxon, topics]) => {
         $('.visualization-spinner').hide()
+        if ((!taxon || taxon.length === 0) && (!topics || topics.length === 0)) {
+            const container = document.getElementById(containerId);
+            if (container) {
+                container.innerHTML = '<div style="color:#888;">' + document.getElementById('viz-content').getAttribute('data-message') + '</div>';
+            }
+            container.classList.add('rendered');
+            return;
+        }
         const annotationSources = [
             {
                 key: 'taxon',

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/PostgresqlDataInterface_Impl.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/PostgresqlDataInterface_Impl.java
@@ -1763,6 +1763,19 @@ public class PostgresqlDataInterface_Impl implements DataInterface {
             return query.getResultList();
         });
     }
+    public List<Object[]> getNamedEntityValuesAndCountByPage(long documentId) throws DatabaseOperationException {
+        return executeOperationSafely((session) -> {
+            // Construct the SQL query to select page_id and coveredtext from the namedentity table
+            String sql = "SELECT ne.page_id, ne.coveredtext AS named_entity_value, ne.typee AS named_entity_type " +
+                    "FROM namedentity ne " +
+                    "WHERE ne.document_id = :documentId";
+
+            var query = session.createNativeQuery(sql)
+                    .setParameter("documentId", documentId);
+
+            return query.getResultList();
+        });
+    }
 
 
     public List<Object[]> getTopicDistributionByPageForDocument(long documentId) throws DatabaseOperationException {

--- a/uce.portal/uce.web/src/main/java/org/texttechnologylab/App.java
+++ b/uce.portal/uce.web/src/main/java/org/texttechnologylab/App.java
@@ -397,6 +397,7 @@ public class App {
                 get("/page/topicEntityRelation", documentApi.getSentenceTopicsWithEntities);
                 get("/page/topicWords", documentApi.getTopicWordsByDocument);
                 get("/unifiedTopicSentenceMap", documentApi.getUnifiedTopicToSentenceMap);
+                get("/page/namedEntities", documentApi.getDocumentNamedEntitiesByPage);
             });
 
             path("/rag", () -> {

--- a/uce.portal/uce.web/src/main/java/org/texttechnologylab/routes/DocumentApi.java
+++ b/uce.portal/uce.web/src/main/java/org/texttechnologylab/routes/DocumentApi.java
@@ -246,8 +246,8 @@ public class DocumentApi {
 
             for (Object[] row : taxonValuesAndCounts) {
                 var pageMap = new HashMap<String, Object>();
-                pageMap.put("page_id", row[0]);
-                pageMap.put("taxon_value", row[1]);
+                pageMap.put("pageId", row[0]);
+                pageMap.put("taxonValue", row[1]);
                 //var taxonValues = row[1].toString().replaceAll("[\\{\\}]", "").split(",");
                 //pageMap.put("taxon_values", taxonValues);
                 //pageMap.put("taxon_count", row[2]);
@@ -280,8 +280,8 @@ public class DocumentApi {
 
             for (Object[] row : topicDistPerPage) {
                 var pageMap = new HashMap<String, Object>();
-                pageMap.put("page_id", row[0]);
-                pageMap.put("topiclabel", row[1]);
+                pageMap.put("pageId", row[0]);
+                pageMap.put("topicLabel", row[1]);
                 result.add(pageMap);
             }
 
@@ -294,6 +294,39 @@ public class DocumentApi {
                     .render(new ModelAndView(Map.of("information", "Error retrieving document topics."), "defaultError.ftl"));
         }
     });
+
+    public Route getDocumentNamedEntitiesByPage = ((request, response) -> {
+        var documentId = ExceptionUtils.tryCatchLog(() -> Long.parseLong(request.queryParams("documentId")),
+                (ex) -> logger.error("Error: couldn't determine the documentId for entities. ", ex));
+
+        if (documentId == null) {
+            response.status(400);
+            return new CustomFreeMarkerEngine(this.freemarkerConfig)
+                    .render(new ModelAndView(Map.of("information", "Missing documentId parameter"), "defaultError.ftl"));
+        }
+
+        try {
+            var entitiesPerPage = db.getNamedEntityValuesAndCountByPage(documentId);
+            var result = new ArrayList<Map<String, Object>>();
+
+            for (Object[] row : entitiesPerPage) {
+                var pageMap = new HashMap<String, Object>();
+                pageMap.put("pageId", row[0]);
+                pageMap.put("entityValue", row[1]);
+                pageMap.put("entityType", row[2]);
+                result.add(pageMap);
+            }
+
+            response.type("application/json");
+            return new Gson().toJson(result);
+        } catch (Exception ex) {
+            logger.error("Error getting document entities.", ex);
+            response.status(500);
+            return new CustomFreeMarkerEngine(this.freemarkerConfig)
+                    .render(new ModelAndView(Map.of("information", "Error retrieving document entities."), "defaultError.ftl"));
+        }
+    });
+
 
     public Route getSentenceTopicsWithEntities = ((request, response) -> {
         var documentId = ExceptionUtils.tryCatchLog(() -> Long.parseLong(request.queryParams("documentId")),


### PR DESCRIPTION
This PR adds named entities to semantic density visualization. It add route to access named entities and display the entity types in the visualization.
Along with that it handles cases when there is no data available for visualization. 