### PR TITLE
Fix error in logging if query URL is too long

### DIFF
--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/corpus/UCELog.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/corpus/UCELog.java
@@ -14,6 +14,7 @@ public class UCELog extends ModelBase {
     private String ip;
     private String method;
     private String uri;
+    @Column(columnDefinition = "TEXT")
     private String query;
     @Column(columnDefinition = "TEXT")
     private String body;


### PR DESCRIPTION
e.g. if system prompt is sent for RAG