### PR TITLE
Added images to UCE

### DIFF
--- a/uce.portal/resources/templates/js/viewerImage.js
+++ b/uce.portal/resources/templates/js/viewerImage.js
@@ -1,0 +1,12 @@
+$(document).ready(function () {
+    const mimeType = `${document.getMimeType()}`
+    console.log("Loading viewerImage.js for document with type", mimeType)
+
+    const imageBase64 = `${document.getDocumentDataBase64()}`
+
+    let elem = document.getElementById('document-reader-viewer-image-img')
+    elem.style.height = "100vh"
+    elem.src = "data:" + mimeType + ";base64," + imageBase64
+
+    console.log("viewerImage.js loaded")
+})

--- a/uce.portal/resources/templates/reader/components/viewerImage.ftl
+++ b/uce.portal/resources/templates/reader/components/viewerImage.ftl
@@ -1,0 +1,11 @@
+<div class="document-reader-viewer-image">
+    <img id="document-reader-viewer-image-img" width="100%" />
+</div>
+
+<style>
+    <#include "*/css/viewer-image.css">
+</style>
+
+<script>
+    <#include "*/js/viewerImage.js">
+</script>

--- a/uce.portal/resources/templates/reader/documentReaderView.ftl
+++ b/uce.portal/resources/templates/reader/documentReaderView.ftl
@@ -163,6 +163,8 @@
 
                     <#if document.getMimeType() == "application/pdf" ||  document.getMimeType() == "pdf">
                         <#include '*/reader/components/viewerPdf.ftl' />
+                    <#elseif document.getMimeType()?starts_with("image/")>
+                        <#include '*/reader/components/viewerImage.ftl' />
                     <#else>
                         <div class="document-content">
                             <!-- Here we lazily load in the pages -->

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/config/HibernateConf.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/config/HibernateConf.java
@@ -73,6 +73,7 @@ public class HibernateConf {
         metadataSources.addAnnotatedClass(UCELog.class);
         metadataSources.addAnnotatedClass(UCEImport.class);
         metadataSources.addAnnotatedClass(ImportLog.class);
+        metadataSources.addAnnotatedClass(Image.class);
         //negations
         metadataSources.addAnnotatedClass(CompleteNegation.class);
         metadataSources.addAnnotatedClass(Cue.class);

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/config/corpusConfig/CorpusAnnotationConfig.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/config/corpusConfig/CorpusAnnotationConfig.java
@@ -23,6 +23,7 @@ public class CorpusAnnotationConfig {
     private boolean sentence;
     private boolean time;
     private boolean wikipediaLink;
+    private boolean image;
     // negation annos
     private boolean completeNegation;
     private boolean cue;

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/UIMAAnnotation.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/UIMAAnnotation.java
@@ -150,6 +150,13 @@ public class UIMAAnnotation extends ModelBase implements Linkable {
                 }
             }
 
+            if (annotation instanceof Image) {
+                // We render the image at the starting position, no end tag needed
+                var start = annotation.getBegin() - offset - errorOffset;
+                startTags.computeIfAbsent(start, k -> new ArrayList<>()).add(annotation);
+                continue;
+            }
+
             // We need to handle Sentiment a bit differently, as they are sentence or paragraph based annotations.
             if (annotation.getClass() != Sentiment.class && annotation.getClass() != Emotion.class) {
                 if (annotation.getBegin() < getBegin()
@@ -314,7 +321,12 @@ public class UIMAAnnotation extends ModelBase implements Linkable {
         //return StringUtils.AddLineBreaks(StringUtils.CleanText(finalText.toString()), finalText.length());
         //return StringUtils.CleanText(finalText.toString());
         //return coveredText;
-        return StringUtils.replaceCharacterOutsideSpan(StringUtils.replaceCharacterOutsideSpan(StringUtils.CleanText(finalText.toString()), '\n', "<br/>"), ' ', "&nbsp;");
+//        return StringUtils.replaceCharacterOutsideSpan(StringUtils.replaceCharacterOutsideSpan(StringUtils.CleanText(finalText.toString()), '\n', "<br/>"), ' ', "&nbsp;");
+
+        var finalTextString = finalText.toString();
+        finalTextString = StringUtils.replaceCharacterOutsideTags(finalTextString, "\n", "<br/>");
+        finalTextString = StringUtils.replaceCharacterOutsideTags(finalTextString, " ", "&nbsp;");
+        return finalTextString;
     }
 
     private String generateMultiHTMLTag(List<UIMAAnnotation> annotations) {
@@ -381,6 +393,8 @@ public class UIMAAnnotation extends ModelBase implements Linkable {
             return String.format(
                     "<span class='annotation custom-context-menu focus' title='%1$s'>",
                     includeTitle ? focus.getCoveredText() : "");
+        } else if (annotation instanceof Image image) {
+            return "<img width='" + image.getWidth() + "' height='" + image.getHeight() + "' src='" + image.getHTMLImgSrc() + "' /><br/>";
         } else if (annotation instanceof UnifiedTopic topic) {
             // Get the representative topic if available
             String repTopicValue = "";

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/corpus/Document.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/corpus/Document.java
@@ -231,6 +231,12 @@ public class Document extends ModelBase implements WikiModel, Linkable {
     @Fetch(value = FetchMode.SUBSELECT)
     private List<UnifiedTopic> unifiedTopics;
 
+    @Getter
+    @Setter
+    @OneToMany(cascade = CascadeType.ALL)
+    @JoinColumn(name = "document_Id")
+    private List<Image> images;
+
     public Document() {
         metadataTitleInfo = new MetadataTitleInfo();
     }
@@ -406,6 +412,7 @@ public class Document extends ModelBase implements WikiModel, Linkable {
         annotations.addAll(events.stream().filter(a -> a.getBegin() >= pagesBegin && a.getEnd() <= pagesEnd).toList());
         // unifiedTopics
         annotations.addAll(unifiedTopics.stream().filter(a -> a.getBegin() >= pagesBegin && a.getEnd() <= pagesEnd).toList());
+        annotations.addAll(images.stream().filter(a -> a.getBegin() >= pagesBegin && a.getEnd() <= pagesEnd).toList());
 
         annotations.sort(Comparator.comparingInt(UIMAAnnotation::getBegin));
         return annotations;

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/corpus/Image.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/corpus/Image.java
@@ -1,0 +1,46 @@
+package org.texttechnologylab.models.corpus;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.texttechnologylab.annotations.Typesystem;
+import org.texttechnologylab.models.UIMAAnnotation;
+
+import javax.persistence.*;
+
+@Entity
+@Table(name = "image")
+@Typesystem(types = {org.texttechnologylab.annotation.type.Image.class})
+public class Image extends UIMAAnnotation {
+    @Setter
+    @Getter
+    private int width;
+
+    @Setter
+    @Getter
+    private int height;
+
+    @Setter
+    @Getter
+    private String mimeType;
+
+    // Base64 encoded image data
+    @Getter
+    @Setter
+    @Column(columnDefinition = "TEXT")
+    private String src;
+
+    public Image() {
+        super(-1, -1);
+    }
+
+    public Image(int begin, int end) {
+        super(begin, end);
+    }
+
+    public String getHTMLImgSrc() {
+        if (src == null || mimeType == null) {
+            return "";
+        }
+        return "data:" + mimeType + ";base64," + src;
+    }
+}

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/PostgresqlDataInterface_Impl.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/services/PostgresqlDataInterface_Impl.java
@@ -2157,6 +2157,7 @@ public class PostgresqlDataInterface_Impl implements DataInterface {
         Hibernate.initialize(doc.getWikipediaLinks());
         Hibernate.initialize(doc.getLemmas());
         Hibernate.initialize(doc.getUceMetadata());
+        Hibernate.initialize(doc.getImages());
         // init negations
         Hibernate.initialize(doc.getCompleteNegations());
         Hibernate.initialize(doc.getCues());

--- a/uce.portal/uce.corpus-importer/src/main/java/org/texttechnologylab/Importer.java
+++ b/uce.portal/uce.corpus-importer/src/main/java/org/texttechnologylab/Importer.java
@@ -83,6 +83,9 @@ public class Importer {
     );
     private static final String[] COMATIBLE_CAS_FILE_ENDINGS = Arrays.asList("xmi", "bz2", "zip", "gz").toArray(new String[0]);
     private static final Set<String> MIME_TYPES_PDF = Set.of("application/pdf", "pdf");
+    private static final String MIME_TYPE_IMAGE_PREFIX = "image/";
+    // TODO this list must also be used in the frontend to decide if we should show the image viewer
+    private static final Set<String> MIME_TYPES_IMAGES = Set.of("image/jpeg", "image/png");
     private GoetheUniversityService goetheUniversityService;
     private PostgresqlDataInterface_Impl db;
     private RAGService ragService;
@@ -210,6 +213,8 @@ public class Importer {
 
         // Read the corpus config. If this doesn't exist, we cannot import the corpus
         //fixed paths
+        // NOTE the config is not updated if the corpus already exists!
+        // TODO compare configs and show a warning if they differ (except name, ...)
         try (var reader = new FileReader(Paths.get(folderName, "corpusConfig.json").toString())) {
 
             corpusConfig = gson.fromJson(reader, CorpusConfig.class);
@@ -524,6 +529,14 @@ public class Importer {
                 byte[] pdfBytes = jCas.getSofaDataStream().readAllBytes();
                 document.setDocumentData(pdfBytes);
                 logger.info("Document is a PDF: " + document.getMimeType() + " of length " + pdfBytes.length);
+            } else if (document.getMimeType().startsWith(MIME_TYPE_IMAGE_PREFIX) || MIME_TYPES_IMAGES.contains(document.getMimeType())) {
+                document.setFullText("");
+
+                // This is a document that only contains image bytes in the sofa string
+                byte[] imageBytes = jCas.getSofaDataStream().readAllBytes();
+                document.setDocumentData(imageBytes);
+                logger.info("Document is an image: " + document.getMimeType() + " of length " + imageBytes.length);
+
             } else {
                 // by default, we assume text as before
                 document.setFullText(jCas.getDocumentText());
@@ -618,6 +631,11 @@ public class Importer {
             ExceptionUtils.tryCatchLog(
                     () -> setPages(document, jCas, corpusConfig),
                     (ex) -> logImportWarn("This file should have contained OCRPage annotations, but selecting them caused an error.", ex, filePath));
+
+            if (corpusConfig.getAnnotations().isImage())
+                ExceptionUtils.tryCatchLog(
+                        () -> setImages(document, jCas),
+                        (ex) -> logImportWarn("This file should have contained image annotations, but selecting them caused an error.", ex, filePath));
 
             var duration = System.currentTimeMillis() - start;
             logImportInfo("Successfully extracted all annotations from " + filePath, LogStatus.FINISHED, filePath, duration);
@@ -1455,6 +1473,21 @@ public class Importer {
         document.setXscopes(xScopesTotal);
         document.setFocuses(focusesTotal);
         document.setEvents(eventsTotal);
+    }
+
+
+    private void setImages(Document document, JCas jCas) {
+        // create image annotations
+        List<Image> images = new ArrayList<>();
+        for (org.texttechnologylab.annotation.type.Image imageAnno : JCasUtil.select(jCas, org.texttechnologylab.annotation.type.Image.class)) {
+            Image image = new Image(imageAnno.getBegin(), imageAnno.getEnd());
+            image.setWidth(imageAnno.getWidth());
+            image.setHeight(imageAnno.getHeight());
+            image.setMimeType(imageAnno.getMimetype());
+            image.setSrc(imageAnno.getSrc());
+            images.add(image);
+        }
+        document.setImages(images);
     }
 
 


### PR DESCRIPTION
- Import of images as SofA bytes and Image annotation
- Document reader for "image only" documents (i.e. mime type of SofA is "image/...")
- Render images in document reader based on "begin" position in the text
- Replaced "replaceCharacterOutsideSpan" with "replaceCharacterOutsideTags" to make support for more tags easier