### PR TITLE
RAG bot streaming

### DIFF
--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/backgroundtasks/RAGStreamBackgroundTask.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/backgroundtasks/RAGStreamBackgroundTask.java
@@ -1,0 +1,39 @@
+package org.texttechnologylab.backgroundtasks;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.texttechnologylab.exceptions.ExceptionUtils;
+import org.texttechnologylab.models.corpus.Document;
+import org.texttechnologylab.models.rag.*;
+import org.texttechnologylab.services.RAGService;
+
+import java.util.List;
+
+public class RAGStreamBackgroundTask implements Runnable {
+
+    private static final Logger logger = LogManager.getLogger(RAGStreamBackgroundTask.class);
+
+    private final RAGService ragService;
+    private final RAGChatState chatState;
+    private final List<DocumentChunkEmbedding> nearestDocumentChunkEmbeddings;
+    private final List<Document> foundDocuments;
+
+    public RAGStreamBackgroundTask(RAGService ragService, RAGChatState chatState, List<DocumentChunkEmbedding> nearestDocumentChunkEmbeddings, List<Document> foundDocuments) {
+        this.ragService = ragService;
+        this.chatState = chatState;
+        this.nearestDocumentChunkEmbeddings = nearestDocumentChunkEmbeddings;
+        this.foundDocuments = foundDocuments;
+    }
+
+    public void run() {
+        logger.info("Started background task for RAG streaming, chatId: {}", chatState.getChatId());
+
+        // This will internally stream the response from the LLM RAG service and will return the final answer
+        ExceptionUtils.tryCatchLog(
+                () -> ragService.postNewRAGPromptStreaming(chatState, nearestDocumentChunkEmbeddings, foundDocuments),
+                (ex) -> logger.error("Error streaming response from our LLM RAG service for chat " + chatState.getChatId(), ex));
+
+        logger.info("Background task for RAG streaming ended, chatId: {}", chatState.getChatId());
+    }
+
+}

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/dto/RAGCompleteMessageStreamingDto.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/dto/RAGCompleteMessageStreamingDto.java
@@ -1,0 +1,20 @@
+package org.texttechnologylab.models.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class RAGCompleteMessageStreamingDto {
+    // TODO map this to the UCE role class
+    @Setter
+    @Getter
+    private String role;
+
+    @Setter
+    @Getter
+    private String content;
+
+    // TODO would also contain "images", left out for now as we do not support receiving images
+
+    public RAGCompleteMessageStreamingDto() {
+    }
+}

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/dto/RAGCompleteStreamingDto.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/dto/RAGCompleteStreamingDto.java
@@ -1,0 +1,17 @@
+package org.texttechnologylab.models.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+public class RAGCompleteStreamingDto {
+    @Setter
+    @Getter
+    private RAGCompleteMessageStreamingDto message;
+
+    @Setter
+    @Getter
+    private boolean done;
+
+    public RAGCompleteStreamingDto() {
+    }
+}

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/rag/RAGChatMessage.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/rag/RAGChatMessage.java
@@ -12,6 +12,7 @@ public class RAGChatMessage {
     private String message;
     private DateTime created;
     private ArrayList<Document> contextDocuments;
+    private boolean done;
 
     // Images that are sent with the message
     // NOTE that they will use the base64 encoded image in the message payload
@@ -57,6 +58,16 @@ public class RAGChatMessage {
         this.created = DateTime.now();
         this.contextDocuments = new ArrayList<>();
         this.images = new ArrayList<>();
+        // by default, we expect the message to already be finished. this is set to "false" for streaming requests only
+        this.done = false;
+    }
+
+    public boolean isDone() {
+        return done;
+    }
+
+    public void setDone(boolean done) {
+        this.done = done;
     }
 
     public List<Image> getImages() {

--- a/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/rag/RAGChatState.java
+++ b/uce.portal/uce.common/src/main/java/org/texttechnologylab/models/rag/RAGChatState.java
@@ -31,4 +31,8 @@ public class RAGChatState {
         }
         this.messages.add(message);
     }
+
+    public RAGChatMessage getNewestMessage() {
+        return this.messages != null && !this.messages.isEmpty() ? this.messages.getLast() : null;
+    }
 }

--- a/uce.portal/uce.web/src/main/java/org/texttechnologylab/App.java
+++ b/uce.portal/uce.web/src/main/java/org/texttechnologylab/App.java
@@ -436,6 +436,7 @@ public class App {
                 // NOTE we allow also "post" here, as the system prompt can get quite long...
                 post("/new", (registry.get(RAGApi.class)).getNewRAGChat);
                 post("/postUserMessage", (registry.get(RAGApi.class)).postUserMessage);
+                get("/messages", (registry.get(RAGApi.class)).getMessagesForChat);
                 get("/plotTsne", (registry.get(RAGApi.class)).getTsnePlot);
                 get("/sentenceEmbeddings", (registry.get(RAGApi.class)).getSentenceEmbeddings);
             });


### PR DESCRIPTION
This PR adds streaming functionality to the RAG bot. The answer is streamed directly from the Ollama backend to the RAG micro service and to the UCE backend, there the message object is updated in realtime. Users can then poll messages using another endpoint to receive updates, this has been implemented for the UCE web ui already.

Open tasks:
- Implement streaming for OpenAI API and other local models/backends
- Integration of websockets into UCE to enable streaming without polling