### PR TITLE
feat(web): added optional parameter for corpusConfig

### DIFF
--- a/uce.portal/uce.corpus-importer/src/main/java/org/texttechnologylab/uce/corpusimporter/Importer.java
+++ b/uce.portal/uce.corpus-importer/src/main/java/org/texttechnologylab/uce/corpusimporter/Importer.java
@@ -165,13 +165,13 @@ public class Importer {
     public void start(int numThreads) throws DatabaseOperationException {
         logger.info(
                 "\n _   _ _____  _____   _____                           _   \n" +
-                "| | | /  __ \\|  ___| |_   _|                         | |  \n" +
-                "| | | | /  \\/| |__     | | _ __ ___  _ __   ___  _ __| |_ \n" +
-                "| | | | |    |  __|    | || '_ ` _ \\| '_ \\ / _ \\| '__| __|\n" +
-                "| |_| | \\__/\\| |___   _| || | | | | | |_) | (_) | |  | |_ \n" +
-                " \\___/ \\____/\\____/   \\___/_| |_| |_| .__/ \\___/|_|   \\__|\n" +
-                "                                    | |                   \n" +
-                "                                    |_|"
+                        "| | | /  __ \\|  ___| |_   _|                         | |  \n" +
+                        "| | | | /  \\/| |__     | | _ __ ___  _ __   ___  _ __| |_ \n" +
+                        "| | | | |    |  __|    | || '_ ` _ \\| '_ \\ / _ \\| '__| __|\n" +
+                        "| |_| | \\__/\\| |___   _| || | | | | | |_) | (_) | |  | |_ \n" +
+                        " \\___/ \\____/\\____/   \\___/_| |_| |_| .__/ \\___/|_|   \\__|\n" +
+                        "                                    | |                   \n" +
+                        "                                    |_|"
         );
         logger.info("===========> Global Import Id: " + importId);
         logger.info("===========> Importer Number: " + importerNumber);
@@ -222,31 +222,17 @@ public class Importer {
         // NOTE the config is not updated if the corpus already exists!
         // TODO compare configs and show a warning if they differ (except name, ...)
         try (var reader = new FileReader(Paths.get(folderName, "corpusConfig.json").toString(), StandardCharsets.UTF_8)) {
-
             corpusConfig = gson.fromJson(reader, CorpusConfig.class);
-            corpus.setName(corpusConfig.getName());
-            corpus.setLanguage(corpusConfig.getLanguage());
-            corpus.setAuthor(corpusConfig.getAuthor());
-            corpus.setCorpusJsonConfig(gson.toJson(corpusConfig));
-
-            // Let's check if we already have a corpus with that name and
-            // if we want to add to that in the config.
-            if (corpusConfig.isAddToExistingCorpus()) {
-                final var corpusConfig1 = corpusConfig; // This sucks so hard - why doesn't java just do this itself if needed?
-                var existingCorpus = ExceptionUtils.tryCatchLog(() -> db.getCorpusByName(corpusConfig1.getName()),
-                        (ex) -> logger.error("Error getting an existing corpus by name. The corpus config should probably be changed " +
-                                             "to not add to existing corpus then.", ex));
-
-                if (existingCorpus != null) { // If we have the corpus, use that. Else store the new corpus.
+            try {
+                Corpus existingCorpus = CreateDBCorpus(corpus, corpusConfig, db);
+                if (existingCorpus != null) {
                     corpus = existingCorpus;
-                    // In case that we have a corpus already, we load the existing filters if they exist.
-                    if (corpusConfig.getAnnotations().isUceMetadata())
-                        this.uceMetadataFilters = new CopyOnWriteArrayList<>(db.getUCEMetadataFiltersByCorpusId(corpus.getId()));
-                } else {
-                    final var corpus1 = corpus;
-                    ExceptionUtils.tryCatchLog(() -> db.saveCorpus(corpus1),
-                            (ex) -> logger.error("Error saving the corpus.", ex));
+                    if (corpusConfig.getAnnotations().isUceMetadata()) {
+                        this.uceMetadataFilters = new CopyOnWriteArrayList<>(db.getUCEMetadataFiltersByCorpusId(existingCorpus.getId()));
+                    }
                 }
+            } catch (DatabaseOperationException e) {
+                throw new DatabaseOperationException("Error creating or fetching the corpus from the database - cancelling import.", e);
             }
         } catch (JsonIOException | JsonSyntaxException | IOException e) {
             throw new MissingResourceException(
@@ -378,6 +364,33 @@ public class Importer {
 
         logger.info("\n\n=================================\n Done with the corpus import.");
         executor.shutdown();
+    }
+
+    /**
+     *
+     * @param corpus
+     * @param corpusConfig
+     * @param db
+     * @return A {@link Corpus} object if an existing corpus was found otherwise null
+     */
+    public static Corpus CreateDBCorpus(Corpus corpus, CorpusConfig corpusConfig, PostgresqlDataInterface_Impl db) throws DatabaseOperationException {
+        corpus.setName(corpusConfig.getName());
+        corpus.setLanguage(corpusConfig.getLanguage());
+        corpus.setAuthor(corpusConfig.getAuthor());
+        corpus.setCorpusJsonConfig(gson.toJson(corpusConfig));
+
+        // Let's check if we already have a corpus with that name and
+        // if we want to add to that in the config.
+        if (corpusConfig.isAddToExistingCorpus()) {
+            var existingCorpus = db.getCorpusByName(corpusConfig.getName());
+            if (existingCorpus != null) { // If we have the corpus, use that.
+                return existingCorpus;
+            }
+            throw new DatabaseOperationException("The corpus config specified to add to an existing corpus, " +
+                    "but no corpus with the name " + corpusConfig.getName() + " exists.");
+        }
+        db.saveCorpus(corpus);
+        return null;
     }
 
     /**
@@ -513,7 +526,7 @@ public class Importer {
             var exists = db.documentExists(corpus.getId(), document.getDocumentId());
             if (exists) {
                 logger.info("Document with id " + document.getDocumentId()
-                            + " already exists in the corpus " + corpus.getId() + ".");
+                        + " already exists in the corpus " + corpus.getId() + ".");
                 logger.info("Checking if that document was also post-processed yet...");
                 var existingDoc = db.getDocumentByCorpusAndDocumentId(corpus.getId(), document.getDocumentId());
                 if (!existingDoc.isPostProcessed()) {
@@ -938,8 +951,8 @@ public class Importer {
             if (documentAnnotation != null) {
                 try {
                     metadataTitleInfo.setPublished(documentAnnotation.getDateDay() + "."
-                                                   + documentAnnotation.getDateMonth() + "."
-                                                   + documentAnnotation.getDateYear());
+                            + documentAnnotation.getDateMonth() + "."
+                            + documentAnnotation.getDateYear());
                     metadataTitleInfo.setAuthor(documentAnnotation.getAuthor());
                 } catch (Exception ex) {
                     logger.warn("Tried extracting DocumentAnnotation type, it caused an error. Import will be continued as usual.");

--- a/uce.portal/uce.web/src/main/java/org/texttechnologylab/uce/web/routes/ImportExportApi.java
+++ b/uce.portal/uce.web/src/main/java/org/texttechnologylab/uce/web/routes/ImportExportApi.java
@@ -1,11 +1,16 @@
 package org.texttechnologylab.uce.web.routes;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
 import io.javalin.http.Context;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.context.ApplicationContext;
+import org.texttechnologylab.uce.common.config.CorpusConfig;
 import org.texttechnologylab.uce.common.exceptions.DatabaseOperationException;
 import org.texttechnologylab.uce.common.exceptions.ExceptionUtils;
+import org.texttechnologylab.uce.common.models.corpus.Corpus;
 import org.texttechnologylab.uce.common.services.PostgresqlDataInterface_Impl;
 import org.texttechnologylab.uce.common.services.S3StorageService;
 import org.texttechnologylab.uce.common.utils.StringUtils;
@@ -23,6 +28,7 @@ public class ImportExportApi implements UceApi {
     private ApplicationContext serviceContext;
 
     private static final Logger logger = LogManager.getLogger(PostgresqlDataInterface_Impl.class);
+    private static Gson gson = new Gson();
 
     public ImportExportApi(ApplicationContext serviceContext) {
         this.serviceContext = serviceContext;
@@ -87,8 +93,27 @@ public class ImportExportApi implements UceApi {
                     () -> db.getCorpusById(corpusId),
                     (ex) -> logger.error("Couldn't fetch corpus when uploading new document to corpusId " + corpusId, ex));
             if (corpus == null) {
-                ctx.result("Corpus with id " + corpusId + " wasn't found in the database; can't upload document.");
-                return;
+                var corpusConfigRaw = ExceptionUtils.tryCatchLog(
+                        () -> new String(ctx.req().getPart("corpusConfig").getInputStream().readAllBytes(), StandardCharsets.UTF_8),
+                        (ex) -> logger.error("Error getting the corpusConfig that should be used for this document. Aborting.", ex));
+                if (corpusConfigRaw == null) {
+                    ctx.result("Corpus with id " + corpusId + " wasn't found in the database; no config was provided; can't upload document.");
+                    return;
+                }
+                logger.info("Corpus with id " + corpusId + " wasn't found in the database; creating a new corpus with the provided config.");
+                try {
+                    var corpusConfig = gson.fromJson(corpusConfigRaw, CorpusConfig.class);
+                    corpus = new Corpus();
+                    var corpusReturn = Importer.CreateDBCorpus(corpus, corpusConfig, this.db);
+                    if (corpusReturn != null) {
+                        corpus = corpusReturn;
+                    }
+                } catch (JsonIOException | JsonSyntaxException e) {
+                    ctx.result("The corpusConfig provided is not properly formatted.");
+                } catch (DatabaseOperationException e) {
+                    ctx.result("Error creating a new corpus in the database: " + e.getMessage());
+                    return;
+                }
             }
 
             // TODO just use 1 as default? will throw an error if this is null otherwise...
@@ -97,9 +122,10 @@ public class ImportExportApi implements UceApi {
             try (var input = ctx.req().getPart("file").getInputStream()) {
                 var fileName = ctx.req().getPart("file").getSubmittedFileName();
                 // Import the doc in the background
+                final Corpus corpus1 = corpus;
                 var importFuture = CompletableFuture.supplyAsync(() -> {
                     try {
-                        return importer.storeUploadedXMIToCorpusAsync(input, corpus, fileName, documentId);
+                        return importer.storeUploadedXMIToCorpusAsync(input, corpus1, fileName, documentId);
                     } catch (DatabaseOperationException e) {
                         throw new RuntimeException(e);
                     }


### PR DESCRIPTION
Allows corpusConfig file data to be specified when uploading a document via the API endpoint.
In case the requested corpus Id does not exist we go through the same routine the corpus importer does.

Addresses https://github.com/texttechnologylab/UCE/issues/106

This also fixes an issue where corpora were not saved if they didn't have set `addToExistingCorpus: true`

Note this changes the default behavior of addToExistingCorpus which probably was not intended to begin with.
If addToExistingCorpus is set to `true` but no corpus with that name exists we throw an error.

I don't know why the formatter wants to move the logo print by two tabs 🙃 